### PR TITLE
[FEAT] 계정 관련 기능 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,4 +78,11 @@ dependencies {
     implementation("androidx.datastore:datastore-preferences:1.1.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
 
+    // 암호화 SharedPrefences
+    implementation("androidx.security:security-crypto:1.1.0-alpha06")
+
+    // viewModelScope / viewModel() 컴포즈에서 쓰니 함께 권장
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")
+
 }

--- a/app/src/main/java/com/refit/app/MainActivity.kt
+++ b/app/src/main/java/com/refit/app/MainActivity.kt
@@ -37,7 +37,7 @@ class MainActivity : ComponentActivity() {
                 // 알림 클릭 여부 판단
                 val navigateTo = intent?.getStringExtra("navigateTo")
 
-                // 항상 홈으로 시작
+                // 항상 스플래시로 시작
                 MainScreenWithBottomNav(
                     navController = navController,
                     startDestination = "splash"

--- a/app/src/main/java/com/refit/app/MainActivity.kt
+++ b/app/src/main/java/com/refit/app/MainActivity.kt
@@ -40,7 +40,7 @@ class MainActivity : ComponentActivity() {
                 // 항상 홈으로 시작
                 MainScreenWithBottomNav(
                     navController = navController,
-                    startDestination = "home"
+                    startDestination = "splash"
                 )
 
                 // 알림 클릭 시, NavHost 초기화 후 알림화면으로 이동

--- a/app/src/main/java/com/refit/app/MainActivity.kt
+++ b/app/src/main/java/com/refit/app/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.health.connect.client.PermissionController
 import com.refit.app.data.health.HealthRepo
 import com.refit.app.network.RetrofitInstance
 import com.refit.app.network.TokenManager
+import com.refit.app.network.UserPrefs
 
 class MainActivity : ComponentActivity() {
     @RequiresApi(Build.VERSION_CODES.O)
@@ -24,6 +25,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         TokenManager.init(this)
         RetrofitInstance.init(this)
+        UserPrefs.init(this) // 사용자 정보 prefs
 
         enableEdgeToEdge()
 

--- a/app/src/main/java/com/refit/app/data/auth/api/AuthApi.kt
+++ b/app/src/main/java/com/refit/app/data/auth/api/AuthApi.kt
@@ -7,6 +7,7 @@ import com.refit.app.data.auth.model.SignupResponse
 import com.refit.app.data.auth.model.UtilResponse
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.Headers
 import retrofit2.http.POST
 
 interface AuthApi {

--- a/app/src/main/java/com/refit/app/data/auth/api/AuthApi.kt
+++ b/app/src/main/java/com/refit/app/data/auth/api/AuthApi.kt
@@ -1,8 +1,11 @@
 package com.refit.app.data.auth.api
 
+import com.refit.app.data.auth.model.LoginRequest
+import com.refit.app.data.auth.model.LoginResponse
 import com.refit.app.data.auth.model.SignupAllRequest
 import com.refit.app.data.auth.model.SignupResponse
 import com.refit.app.data.auth.model.UtilResponse
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.POST
 
@@ -10,7 +13,7 @@ interface AuthApi {
     @POST("/auth/join")
     suspend fun join(@Body body: SignupAllRequest): UtilResponse<SignupResponse>
 
-    @POST("auth/login")
+    @POST("/auth/login")
     suspend fun login(
         @Body req: LoginRequest
     ): Response<UtilResponse<LoginResponse>>

--- a/app/src/main/java/com/refit/app/data/auth/api/AuthApi.kt
+++ b/app/src/main/java/com/refit/app/data/auth/api/AuthApi.kt
@@ -1,0 +1,17 @@
+package com.refit.app.data.auth.api
+
+import com.refit.app.data.auth.model.SignupAllRequest
+import com.refit.app.data.auth.model.SignupResponse
+import com.refit.app.data.auth.model.UtilResponse
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+interface AuthApi {
+    @POST("/auth/join")
+    suspend fun join(@Body body: SignupAllRequest): UtilResponse<SignupResponse>
+
+    @POST("auth/login")
+    suspend fun login(
+        @Body req: LoginRequest
+    ): Response<UtilResponse<LoginResponse>>
+}

--- a/app/src/main/java/com/refit/app/data/auth/model/LoginRequest.kt
+++ b/app/src/main/java/com/refit/app/data/auth/model/LoginRequest.kt
@@ -4,3 +4,10 @@ data class LoginRequest(
     val email: String,
     val password: String
 )
+
+data class LoginResponse(
+    val memberId: Long,
+    val nickname: String,
+    val health: HealthInfoDto?,
+    val refreshToken: String?
+)

--- a/app/src/main/java/com/refit/app/data/auth/model/LoginRequest.kt
+++ b/app/src/main/java/com/refit/app/data/auth/model/LoginRequest.kt
@@ -1,0 +1,6 @@
+package com.refit.app.data.auth.model
+
+data class LoginRequest(
+    val email: String,
+    val password: String
+)

--- a/app/src/main/java/com/refit/app/data/auth/model/SignupRequest.kt
+++ b/app/src/main/java/com/refit/app/data/auth/model/SignupRequest.kt
@@ -1,0 +1,44 @@
+package com.refit.app.data.auth.model
+
+data class UtilResponse<T>(val code: String, val message: String, val data: T?)
+
+data class SignupResponse(val id: Long)
+
+data class SignupAllRequest(
+    val signup: SignupRequest,
+    val concerns: ConcernRequest
+)
+
+data class SignupRequest (
+    val email: String,
+    val nickName: String,
+    val memberName: String,
+    val password: String,
+    val zipcode: String,
+    val roadAddress: String,
+    val detailAddress: String,
+    val birthday: String, // 'yyyy-MM-dd' 형식
+    val phoneNumber: String
+)
+
+data class ConcernRequest(
+    val health: HealthInfoDto,
+    val hair: HairInfoDto,
+    val skin: SkinInfoDto
+)
+
+data class HealthInfoDto(
+    val eyeHealth: Int, val fatigue: Int, val sleepStress: Int,
+    val immuneCare: Int, val muscleHealth: Int, val gutHealth: Int,
+    val bloodCirculation: Int
+)
+
+data class HairInfoDto(
+    val hairLoss: Int, val damagedHair: Int, val scalpTrouble: Int, val dandruff: Int
+)
+
+data class SkinInfoDto(
+    val atopic: Int, val acne: Int, val whitening: Int, val sebum: Int,
+    val innerDryness: Int, val wrinkles: Int, val enlargedPores: Int,
+    val redness: Int, val keratin: Int
+)

--- a/app/src/main/java/com/refit/app/network/RetrofitInstance.kt
+++ b/app/src/main/java/com/refit/app/network/RetrofitInstance.kt
@@ -23,7 +23,10 @@ object RetrofitInstance {
         if (initialized) return
 
         val debug = isDebuggable(context)
+
+        // 로깅 인터셉터 - Authorization 헤더 마스킹
         val logging = HttpLoggingInterceptor().apply {
+            redactHeader("Authorization")
             level = if (debug) HttpLoggingInterceptor.Level.BODY
             else HttpLoggingInterceptor.Level.BASIC
         }
@@ -39,6 +42,7 @@ object RetrofitInstance {
             .connectTimeout(60, TimeUnit.SECONDS)
             .readTimeout(60, TimeUnit.SECONDS)
             .writeTimeout(60, TimeUnit.SECONDS)
+            .addInterceptor(logging)
             .addInterceptor(TokenInterceptor())
             .addInterceptor(logging)
             .build()

--- a/app/src/main/java/com/refit/app/network/TokenInterceptor.kt
+++ b/app/src/main/java/com/refit/app/network/TokenInterceptor.kt
@@ -5,10 +5,21 @@ import okhttp3.Response
 
 class TokenInterceptor : Interceptor {
     override fun intercept(chain: Interceptor.Chain): Response {
-        val access = TokenManager.getAccessToken()
-        val req = chain.request().newBuilder().apply {
-            if (!access.isNullOrBlank()) addHeader("Authorization", "Bearer $access")
-        }.build()
-        return chain.proceed(req)
+        val req = chain.request()
+
+        // 이 호출이 토큰을 필요로 하는지 여부 확인
+        val requiresAuth = req.header("Requires-Auth")?.equals("true", ignoreCase = true) == true
+
+        val builder = req.newBuilder()
+            .removeHeader("Requires-Auth")
+
+        // 토큰이 필요한 경우에만 Authorization 추가
+        if (requiresAuth) {
+            val access = TokenManager.getAccessToken()
+            if (!access.isNullOrBlank() && req.header("Authorization").isNullOrBlank()) {
+                builder.addHeader("Authorization", "Bearer $access")
+            }
+        }
+        return chain.proceed(builder.build())
     }
 }

--- a/app/src/main/java/com/refit/app/network/TokenInterceptor.kt
+++ b/app/src/main/java/com/refit/app/network/TokenInterceptor.kt
@@ -1,13 +1,14 @@
 package com.refit.app.network
 
 import okhttp3.Interceptor
+import okhttp3.Response
 
 class TokenInterceptor : Interceptor {
-    override fun intercept(chain: Interceptor.Chain) = chain.proceed(
-        chain.request().newBuilder().apply {
-            TokenManager.getToken()?.takeIf { it.isNotBlank() }?.let {
-                addHeader("Authorization", "Bearer $it")
-            }
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val access = TokenManager.getAccessToken()
+        val req = chain.request().newBuilder().apply {
+            if (!access.isNullOrBlank()) addHeader("Authorization", "Bearer $access")
         }.build()
-    )
+        return chain.proceed(req)
+    }
 }

--- a/app/src/main/java/com/refit/app/network/TokenManager.kt
+++ b/app/src/main/java/com/refit/app/network/TokenManager.kt
@@ -4,12 +4,23 @@ import android.content.Context
 import android.content.SharedPreferences
 
 object TokenManager {
-    private const val PREFS_NAME = "refit_prefs"
-    private const val TOKEN_KEY = "auth_token"
-    private lateinit var prefs: SharedPreferences
+    private const val SECURE_PREFS_NAME = "refit_secure_prefs"
+    private const val KEY_ACCESS = "access_token"
+    private const val KEY_REFRESH = "refresh_token"
+    private lateinit var securePrefs: SharedPreferences
 
     fun init(context: Context) {
-        prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        val masterKey = MasterKey.Builder(context)
+            .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+            .build()
+
+        securePrefs = EncryptedSharedPreferences.create(
+            context,
+            SECURE_PREFS_NAME,
+            masterKey,
+            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+        )
     }
     fun getToken(): String? {
         if (!::prefs.isInitialized) return null

--- a/app/src/main/java/com/refit/app/network/TokenManager.kt
+++ b/app/src/main/java/com/refit/app/network/TokenManager.kt
@@ -2,6 +2,8 @@ package com.refit.app.network
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
 
 object TokenManager {
     private const val SECURE_PREFS_NAME = "refit_secure_prefs"
@@ -22,11 +24,36 @@ object TokenManager {
             EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
         )
     }
-    fun getToken(): String? {
-        if (!::prefs.isInitialized) return null
-        val token = prefs.getString(TOKEN_KEY, null)
-        return if (token == "null") null else token
+
+    @Synchronized fun getAccessToken(): String? =
+        securePrefs.getString(KEY_ACCESS, null).takeUnless { it.isNullOrBlank() || it == "null" }
+
+    @Synchronized fun getRefreshToken(): String? =
+        securePrefs.getString(KEY_REFRESH, null).takeUnless { it.isNullOrBlank() || it == "null" }
+
+    @Synchronized fun saveTokens(access: String?, refresh: String?) {
+        // refresh 가 null이면 기존 refresh 유지 (서버가 미회전 시)
+        val currentRefresh = getRefreshToken()
+        securePrefs.edit()
+            .putString(KEY_ACCESS, access)
+            .putString(KEY_REFRESH, refresh ?: currentRefresh)
+            .apply()
     }
-    fun saveToken(token: String?) { if (::prefs.isInitialized) prefs.edit().putString(TOKEN_KEY, token).apply() }
-    fun clearToken() { if (::prefs.isInitialized) prefs.edit().remove(TOKEN_KEY).apply() }
+
+    @Synchronized fun saveAccess(access: String?) {
+        securePrefs.edit().putString(KEY_ACCESS, access).apply()
+    }
+
+    @Synchronized fun saveRefresh(refresh: String?) {
+        securePrefs.edit().putString(KEY_REFRESH, refresh).apply()
+    }
+
+    @Synchronized fun clearAll() {
+        securePrefs.edit().remove(KEY_ACCESS).remove(KEY_REFRESH).apply()
+    }
+
+    // 역호환: 기존 코드 사용 시
+    fun getToken(): String? = getAccessToken()
+    fun saveToken(token: String?) = saveAccess(token)
+    fun clearToken() = saveAccess(null)
 }

--- a/app/src/main/java/com/refit/app/network/UserPrefs.kt
+++ b/app/src/main/java/com/refit/app/network/UserPrefs.kt
@@ -1,0 +1,49 @@
+package com.refit.app.network
+
+import android.content.Context
+import android.content.SharedPreferences
+import com.google.gson.Gson
+import com.refit.app.data.auth.model.HealthInfoDto
+
+object UserPrefs {
+    private const val PREFS_NAME = "refit_user_prefs"
+    private const val KEY_MEMBER_ID = "member_id"
+    private const val KEY_NICKNAME  = "nickname"
+    private const val KEY_HEALTH    = "health_json"
+
+    private lateinit var prefs: SharedPreferences
+    private val gson by lazy { Gson() }
+
+    fun init(context: Context) {
+        prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+    }
+
+    fun saveUser(memberId: Long?, nickname: String?, health: HealthInfoDto?) {
+        prefs.edit().apply {
+            if (memberId != null) putLong(KEY_MEMBER_ID, memberId) else remove(KEY_MEMBER_ID)
+            putString(KEY_NICKNAME, nickname ?: "")
+            putString(KEY_HEALTH, health?.let { gson.toJson(it) } ?: "")
+        }.apply()
+    }
+
+    fun getMemberId(): Long? {
+        if (!::prefs.isInitialized) return null
+        val v = prefs.getLong(KEY_MEMBER_ID, -1L)
+        return if (v > 0) v else null
+    }
+    fun getNickname(): String? =
+        if (!::prefs.isInitialized) null
+        else prefs.getString(KEY_NICKNAME, null)?.takeIf { it.isNotBlank() }
+
+    fun getHealth(): HealthInfoDto? =
+        if (!::prefs.isInitialized) null
+        else prefs.getString(KEY_HEALTH, null)
+            ?.takeIf { it.isNotBlank() }
+            ?.let { gson.fromJson(it, HealthInfoDto::class.java) }
+
+    fun clear() {
+        if (!::prefs.isInitialized) return
+        prefs.edit().clear().apply()
+    }
+
+}

--- a/app/src/main/java/com/refit/app/ui/composable/auth/ChipGroupSingle.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/auth/ChipGroupSingle.kt
@@ -16,7 +16,7 @@ fun ChipGroupSingle(
 ) {
     FlowRow(
         horizontalArrangement = Arrangement.spacedBy(10.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+        verticalArrangement = Arrangement.spacedBy(5.dp)
     ) {
         options.forEach { opt ->
             SelectableChip(

--- a/app/src/main/java/com/refit/app/ui/composable/auth/SectionHeader.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/auth/SectionHeader.kt
@@ -51,7 +51,7 @@ fun SectionHeader(
             text = title,
             style = MaterialTheme.typography.titleLarge.copy(
                 fontWeight = FontWeight.Bold,
-                fontSize = 24.sp
+                fontSize = 18.sp
             ),
             color = color,
             fontFamily = Pretendard,

--- a/app/src/main/java/com/refit/app/ui/composable/auth/SelectableChip.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/auth/SelectableChip.kt
@@ -33,7 +33,7 @@ fun SelectableChip(
             text = text,
             modifier = Modifier.padding(horizontal = 25.dp, vertical = 8.dp),
             style = MaterialTheme.typography.labelLarge.copy(
-                fontSize = 20.sp,
+                fontSize = 15.sp,
                 fontWeight = FontWeight.SemiBold,
                 lineHeight = 20.sp,
                 fontFamily = Pretendard,

--- a/app/src/main/java/com/refit/app/ui/composable/common/MainScreenWithBottomNav.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/common/MainScreenWithBottomNav.kt
@@ -107,10 +107,16 @@ fun MainScreenWithBottomNav(
                 composable("auth/login") {
                     LoginScreen(
                         onClose = { /* 필요시 */ },
-                        onSignup = { navController.navigate("auth/signup") }
-
+                        onSignup = { navController.navigate("auth/signup") },
+                        onLoggedIn = {
+                            navController.navigate("home") {
+                                popUpTo("auth/login") { inclusive = true } // 뒤로가기로 로그인 안 돌아오게
+                                launchSingleTop = true
+                            }
+                        }
                     )
                 }
+
                 // 회원가입 네비 그래프
                 navigation(
                     startDestination = "auth/signup1",

--- a/app/src/main/java/com/refit/app/ui/composable/common/MainScreenWithBottomNav.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/common/MainScreenWithBottomNav.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -35,6 +36,7 @@ import com.refit.app.ui.screen.SignupStep2Screen
 import com.refit.app.ui.screen.SignupStep3Screen
 import com.refit.app.ui.screen.SplashScreen
 import com.refit.app.ui.screen.WishScreen
+import com.refit.app.ui.viewmodel.auth.SignupViewModel
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
@@ -112,20 +114,22 @@ fun MainScreenWithBottomNav(
                     )
                 }
                 composable("auth/signup2") {
+                    val vm: SignupViewModel = viewModel()
                     SignupStep2Screen(
-                        selectedSkinType = null,
-                        selectedSkinConcerns = emptySet(),
-                        selectedScalpConcerns = emptySet(),
-                        selectedHealthConcerns = emptySet(),
-                        onSkinTypeChange = { /* vm에 전달 */ },
-                        onToggleSkinConcern = { /* vm에 전달 */ },
-                        onToggleScalpConcern = { /* vm에 전달 */ },
-                        onToggleHealthConcern = { /* vm에 전달 */ },
+                        selectedSkinType = vm.uiState.skinType,
+                        selectedSkinConcerns = vm.uiState.skinConcerns,
+                        selectedScalpConcerns = vm.uiState.scalpConcerns,
+                        selectedHealthConcerns = vm.uiState.healthConcerns,
+                        onSkinTypeChange = vm::setSkinType,
+                        onToggleSkinConcern = vm::toggleSkinConcern,
+                        onToggleScalpConcern = vm::toggleScalpConcern,
+                        onToggleHealthConcern = vm::toggleHealthConcern,
                         onBack = { navController.popBackStack() },
                         onNextOrSubmit = { navController.navigate("auth/signup3") },
-                        submitEnabled = true
+                        submitEnabled = vm.isStep2Valid
                     )
                 }
+
                 composable("auth/signup3") {
                     SignupStep3Screen(
                         nickname = null, // SharedPreferences에서 닉네임 꺼내서 넘기면 됨

--- a/app/src/main/java/com/refit/app/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/HomeScreen.kt
@@ -21,32 +21,6 @@ import com.refit.app.network.UserPrefs
 
 @Composable
 fun HomeScreen(navController: NavController) {
-
-    /*
-    // 로그 찍어보기
-    LaunchedEffect(Unit) {
-        // 토큰 읽기 (EncryptedSharedPreferences)
-        val access = TokenManager.getAccessToken()
-        val refresh = TokenManager.getRefreshToken()
-
-        // 프로필 읽기 (일반 SharedPreferences)
-        val memberId = UserPrefs.getMemberId()
-        val nickname = UserPrefs.getNickname()
-        val health   = UserPrefs.getHealth()
-
-        fun mask(s: String?): String =
-            when {
-                s.isNullOrBlank() -> "null"
-                s.length <= 12 -> "****"
-                else -> "${s.take(6)}...${s.takeLast(6)}"
-            }
-
-        Log.d("AuthDebug", "Access = ${mask(access)}")
-        Log.d("AuthDebug", "Refresh = ${mask(refresh)}")
-        Log.d("AuthDebug", "User    = memberId=$memberId, nickname=$nickname, health=$health")
-    }
-    */
-
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/refit/app/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.refit.app.ui.screen
 
+import android.util.Log
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
@@ -14,9 +15,38 @@ import androidx.navigation.NavController
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.LaunchedEffect
+import com.refit.app.network.TokenManager
+import com.refit.app.network.UserPrefs
 
 @Composable
 fun HomeScreen(navController: NavController) {
+
+    /*
+    // 로그 찍어보기
+    LaunchedEffect(Unit) {
+        // 토큰 읽기 (EncryptedSharedPreferences)
+        val access = TokenManager.getAccessToken()
+        val refresh = TokenManager.getRefreshToken()
+
+        // 프로필 읽기 (일반 SharedPreferences)
+        val memberId = UserPrefs.getMemberId()
+        val nickname = UserPrefs.getNickname()
+        val health   = UserPrefs.getHealth()
+
+        fun mask(s: String?): String =
+            when {
+                s.isNullOrBlank() -> "null"
+                s.length <= 12 -> "****"
+                else -> "${s.take(6)}...${s.takeLast(6)}"
+            }
+
+        Log.d("AuthDebug", "Access = ${mask(access)}")
+        Log.d("AuthDebug", "Refresh = ${mask(refresh)}")
+        Log.d("AuthDebug", "User    = memberId=$memberId, nickname=$nickname, health=$health")
+    }
+    */
+
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/refit/app/ui/screen/LoginScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/LoginScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -33,8 +34,12 @@ import com.refit.app.ui.viewmodel.auth.AuthViewModel
 fun LoginScreen(
     onClose: () -> Unit,
     onSignup: () -> Unit,
+    onLoggedIn: () -> Unit,
     vm: AuthViewModel = viewModel()
 ) {
+    LaunchedEffect(vm.loggedIn) {
+        if (vm.loggedIn) onLoggedIn()
+    }
    // 배경
     Scaffold { padding ->
         Box (
@@ -151,7 +156,8 @@ private fun LoginScreenPreview() {
     MaterialTheme {
         LoginScreen(
             onClose = {},
-            onSignup = {}
+            onSignup = {},
+            onLoggedIn = {}
         )
     }
 }

--- a/app/src/main/java/com/refit/app/ui/screen/MyScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/MyScreen.kt
@@ -9,13 +9,18 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import com.refit.app.R
+import com.refit.app.network.TokenManager
+import com.refit.app.network.UserPrefs
 
 @Composable
 fun MyScreen(navController: NavController) {
@@ -40,5 +45,33 @@ fun MyScreen(navController: NavController) {
             Spacer(Modifier.width(8.dp))
             Text("찜 목록 보기")
         }
+        Spacer(Modifier.height(16.dp))
+
+        Button(
+            onClick = {
+                // 토큰/유저정보 모두 삭제
+                TokenManager.clearAll()
+                UserPrefs.clear()
+
+                // 로그인 화면으로 이동 (뒤로가기 시 홈 안 뜨도록 스택 정리)
+                navController.navigate("auth/login") {
+                    popUpTo("home") { inclusive = true } // 필요 시 시작 지점 route로 조정
+                    launchSingleTop = true
+                }
+            },
+            shape = RoundedCornerShape(12.dp)
+        ) {
+            Text("로그아웃(임시)")
+        }
+
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800)
+@Composable
+private fun PreviewMyScreen() {
+    MaterialTheme {
+        val nav = rememberNavController()
+        MyScreen(navController = nav)
     }
 }

--- a/app/src/main/java/com/refit/app/ui/screen/SignupStep1Screen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/SignupStep1Screen.kt
@@ -21,8 +21,6 @@ import androidx.compose.ui.unit.sp
 import com.refit.app.ui.theme.Pretendard
 import com.refit.app.ui.viewmodel.auth.SignupViewModel
 
-private val INPUT_HEIGHT = 56.dp
-
 @Composable
 fun SignupStep1Screen(
     onBack: () -> Unit,

--- a/app/src/main/java/com/refit/app/ui/screen/SignupStep2Screen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/SignupStep2Screen.kt
@@ -114,7 +114,7 @@ fun SignupStep2Screen(
                 },
                 style = headerTextStyle,
                 color = Color(0xFF4A4A4A),
-                fontSize = 25.sp,
+                fontSize = 18.sp,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = autoIconSize),
@@ -131,7 +131,7 @@ fun SignupStep2Screen(
             ) {
                 Column(
                     modifier = Modifier.padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(20.dp)
+                    verticalArrangement = Arrangement.spacedBy(18.dp)
                 ) {
                     SectionHeader(
                         title = "피부 타입",

--- a/app/src/main/java/com/refit/app/ui/screen/SignupStep3Screen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/SignupStep3Screen.kt
@@ -153,4 +153,3 @@ private fun PreviewSignupComplete() {
         )
     }
 }
-

--- a/app/src/main/java/com/refit/app/ui/screen/SignupStep3Screen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/SignupStep3Screen.kt
@@ -102,7 +102,7 @@ fun SignupStep3Screen(
                         append("회원가입이 완료되었어요.")
                     }
                 },
-                fontSize = 25.sp,
+                fontSize = 20.sp,
                 lineHeight = 36.sp,
                 color = Color.Black,
                 fontWeight = FontWeight.Bold,
@@ -116,7 +116,7 @@ fun SignupStep3Screen(
                     }
                     append("과 함께\n나만의 뷰티·헬스 루틴을 시작해요!")
                 },
-                fontSize = 25.sp,
+                fontSize = 20.sp,
                 lineHeight = 36.sp,
                 color = Color.Black,
                 fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/refit/app/ui/screen/SplashScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/SplashScreen.kt
@@ -1,0 +1,65 @@
+package com.refit.app.ui.screen
+
+import android.content.Context
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.refit.app.R
+
+@Composable
+fun SplashScreen(
+    onDecide: (loggedIn: Boolean) -> Unit,
+    preview: Boolean = false
+) {
+    val context = LocalContext.current
+
+    // 프리뷰가 아니면 실제 분기 수행
+    if (!preview) {
+        LaunchedEffect(Unit) {
+            val prefs = context.getSharedPreferences("refit_prefs", Context.MODE_PRIVATE)
+            val token = prefs.getString("auth_token", null)
+            val isLoggedIn = !token.isNullOrBlank()
+            onDecide(isLoggedIn)
+        }
+    }
+
+    // UI
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_login_logo),
+                contentDescription = null,
+                modifier = Modifier.size(250.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 800)
+@Composable
+private fun PreviewSplashScreen() {
+    MaterialTheme {
+        SplashScreen(
+            onDecide = {},
+            preview = true
+        )
+    }
+}

--- a/app/src/main/java/com/refit/app/ui/screen/SplashScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/SplashScreen.kt
@@ -1,6 +1,7 @@
 package com.refit.app.ui.screen
 
 import android.content.Context
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -21,6 +22,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.refit.app.R
+import com.refit.app.network.TokenManager
 import kotlinx.coroutines.delay
 
 @Composable
@@ -29,7 +31,7 @@ fun SplashScreen(
     preview: Boolean = false,
     minDurationMs: Long = 1000L  // 최소 노출 시간
 ) {
-    val context = LocalContext.current
+    // val context = LocalContext.current
 
     LaunchedEffect(preview) {
         if (preview) return@LaunchedEffect
@@ -37,9 +39,8 @@ fun SplashScreen(
         val start = System.currentTimeMillis()
 
         // 로그인 여부 판단 (현재 사용중인 SharedPreferences 로직 유지)
-        val prefs = context.getSharedPreferences("refit_prefs", Context.MODE_PRIVATE)
-        val token = prefs.getString("auth_token", null)
-        val isLoggedIn = !token.isNullOrBlank()
+        val access = TokenManager.getAccessToken()
+        val isLoggedIn = !access.isNullOrBlank()
 
         // 최소 노출 시간 보장
         val elapsed = System.currentTimeMillis() - start

--- a/app/src/main/java/com/refit/app/ui/screen/SplashScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/SplashScreen.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -18,25 +21,35 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.refit.app.R
+import kotlinx.coroutines.delay
 
 @Composable
 fun SplashScreen(
     onDecide: (loggedIn: Boolean) -> Unit,
-    preview: Boolean = false
+    preview: Boolean = false,
+    minDurationMs: Long = 1000L  // 최소 노출 시간
 ) {
     val context = LocalContext.current
 
-    // 프리뷰가 아니면 실제 분기 수행
-    if (!preview) {
-        LaunchedEffect(Unit) {
-            val prefs = context.getSharedPreferences("refit_prefs", Context.MODE_PRIVATE)
-            val token = prefs.getString("auth_token", null)
-            val isLoggedIn = !token.isNullOrBlank()
-            onDecide(isLoggedIn)
+    LaunchedEffect(preview) {
+        if (preview) return@LaunchedEffect
+
+        val start = System.currentTimeMillis()
+
+        // 로그인 여부 판단 (현재 사용중인 SharedPreferences 로직 유지)
+        val prefs = context.getSharedPreferences("refit_prefs", Context.MODE_PRIVATE)
+        val token = prefs.getString("auth_token", null)
+        val isLoggedIn = !token.isNullOrBlank()
+
+        // 최소 노출 시간 보장
+        val elapsed = System.currentTimeMillis() - start
+        if (elapsed < minDurationMs) {
+            delay(minDurationMs - elapsed)
         }
+
+        onDecide(isLoggedIn)
     }
 
-    // UI
     Box(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/refit/app/ui/viewmodel/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/refit/app/ui/viewmodel/auth/AuthViewModel.kt
@@ -4,30 +4,101 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.refit.app.data.auth.api.AuthApi
+import com.refit.app.data.auth.model.LoginRequest
+import com.refit.app.network.RetrofitInstance
+import com.refit.app.network.TokenManager
+import com.refit.app.network.UserPrefs
+import kotlinx.coroutines.launch
 
 class AuthViewModel : ViewModel() {
     var email by mutableStateOf("")
         private set
-
     var password by mutableStateOf("")
         private set
-
+    var loading by mutableStateOf(false)
+        private set
     var error by mutableStateOf<String?>(null)
         private set
+    var loggedIn by mutableStateOf(false)
+        private set
 
-    fun onEmailChange(v: String) {email = v}
-    fun onPasswordChange(v: String) {password = v}
+    fun onEmailChange(v: String)    { email = v.trim() }
+    fun onPasswordChange(v: String) { password = v }
+    fun clearError()                { error = null }
 
     fun login() {
-        error = if (email.isBlank() || password.isBlank()) {
-            "아이디 또는 비밀번호를 확인해주세요."
-        } else null
+        if (email.isBlank() || password.isBlank()) {
+            error = "아이디 또는 비밀번호를 확인해주세요."
+            return
+        }
+
+        viewModelScope.launch {
+            loading = true
+            error = null
+            loggedIn = false
+
+            try {
+                val api = RetrofitInstance.create(AuthApi::class.java)
+                val resp = api.login(LoginRequest(email = email, password = password))
+
+                if (!resp.isSuccessful) {
+                    error = "로그인 실패 (${resp.code()})"
+                    return@launch
+                }
+
+                val body = resp.body()
+                if (body == null) {
+                    error = "응답 본문이 없습니다."
+                    return@launch
+                }
+
+                // 1) 헤더에서 access token 추출
+                val bearer = resp.headers()["Authorization"] ?: resp.headers()["authorization"]
+                val access = extractBearer(bearer)
+
+                // 2) 바디에서 refresh / 프로필 데이터 추출
+                val data = body.data
+                val refresh = data?.refreshToken
+
+                // 3) 저장
+                TokenManager.saveTokens(access = access, refresh = refresh)
+                UserPrefs.saveUser(
+                    memberId = data?.memberId,
+                    nickname = data?.nickname,
+                    health   = data?.health
+                )
+
+                // access가 비어있어도(예외상황) refresh로 재발급 로직을 이후에 돌릴 수 있으니 성공 처리
+                loggedIn = true
+
+            } catch (t: Throwable) {
+                error = t.message ?: "네트워크 오류가 발생했습니다."
+            } finally {
+                loading = false
+            }
+        }
     }
 
+    fun logout() {
+        TokenManager.clearAll()
+        UserPrefs.clear()
+        loggedIn = false
+        email = ""
+        password = ""
+        error = null
+    }
     fun loginKakao() {
 
     }
-
-    fun clearError() {error = null}
+    private fun extractBearer(header: String?): String? {
+        if (header.isNullOrBlank()) return null
+        val parts = header.trim().split(" ")
+        return when {
+            parts.size == 2 && parts[0].equals("Bearer", ignoreCase = true) -> parts[1].trim()
+            else -> header.trim()
+        }.takeIf { it.isNotBlank() }
+    }
 
 }

--- a/app/src/main/java/com/refit/app/ui/viewmodel/auth/SignupUiState.kt
+++ b/app/src/main/java/com/refit/app/ui/viewmodel/auth/SignupUiState.kt
@@ -12,5 +12,10 @@ data class SignupUiState (
     val birthday: LocalDate? = null,
     val zipcode: String = "",
     val roadAddress: String = "",
-    val detailAddress: String = ""
+    val detailAddress: String = "",
+
+    val skinType: String? = null,
+    val skinConcerns: Set<String> = emptySet(),
+    val scalpConcerns: Set<String> = emptySet(),
+    val healthConcerns: Set<String> = emptySet()
     )

--- a/app/src/main/java/com/refit/app/ui/viewmodel/auth/SignupViewModel.kt
+++ b/app/src/main/java/com/refit/app/ui/viewmodel/auth/SignupViewModel.kt
@@ -1,11 +1,13 @@
 package com.refit.app.ui.viewmodel.auth
 
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import java.time.LocalDate
 
 class SignupViewModel : ViewModel() {
-    var uiState: SignupUiState = SignupUiState()
+    var uiState by mutableStateOf(SignupUiState())
         private set
 
     fun onEmail(v: String)            { uiState = uiState.copy(email = v.trim()) }
@@ -18,6 +20,41 @@ class SignupViewModel : ViewModel() {
     fun onZipcode(v: String)          { uiState = uiState.copy(zipcode = v.take(5)) }
     fun onRoad(v: String)             { uiState = uiState.copy(roadAddress = v) }
     fun onDetail(v: String)           { uiState = uiState.copy(detailAddress = v) }
+
+    // ---- step2 전용 핸들러들 ----
+    private val EXCLUSIVE = "해당없음"
+
+    fun setSkinType(v: String?) {
+        uiState = uiState.copy(skinType = v)
+    }
+
+    private fun toggleWithExclusive(current: Set<String>, item: String): Set<String> {
+        return if (item == EXCLUSIVE) {
+            setOf(EXCLUSIVE)                     // '해당없음' 단독 선택
+        } else {
+            val base = current - EXCLUSIVE       // '해당없음'이 켜져있으면 해제
+            if (item in base) base - item else base + item
+        }
+    }
+
+    fun toggleSkinConcern(item: String) {
+        uiState = uiState.copy(
+            skinConcerns = toggleWithExclusive(uiState.skinConcerns, item)
+        )
+    }
+
+    fun toggleScalpConcern(item: String) {
+        uiState = uiState.copy(
+            scalpConcerns = toggleWithExclusive(uiState.scalpConcerns, item)
+        )
+    }
+
+    fun toggleHealthConcern(item: String) {
+        uiState = uiState.copy(
+            healthConcerns = toggleWithExclusive(uiState.healthConcerns, item)
+        )
+    }
+
 
     private val pwRegex = Regex("^(?=.{8,64}$)(?:(?=.*[A-Za-z])(?=.*\\d)|(?=.*[A-Za-z])(?=.*[^\\w\\s])|(?=.*\\d)(?=.*[^\\w\\s])).*$")
 
@@ -32,4 +69,7 @@ class SignupViewModel : ViewModel() {
                 uiState.zipcode.isNotBlank() &&
                 uiState.roadAddress.isNotBlank() &&
                 uiState.detailAddress.isNotBlank()
+
+    val isStep2Valid: Boolean
+        get() = uiState.skinType != null
 }

--- a/app/src/main/java/com/refit/app/ui/viewmodel/auth/SignupViewModel.kt
+++ b/app/src/main/java/com/refit/app/ui/viewmodel/auth/SignupViewModel.kt
@@ -4,12 +4,32 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.refit.app.data.auth.api.AuthApi
+import com.refit.app.data.auth.model.ConcernRequest
+import com.refit.app.data.auth.model.HairInfoDto
+import com.refit.app.data.auth.model.HealthInfoDto
+import com.refit.app.data.auth.model.SignupAllRequest
+import com.refit.app.data.auth.model.SignupRequest
+import com.refit.app.data.auth.model.SkinInfoDto
+import com.refit.app.network.RetrofitInstance
+import kotlinx.coroutines.launch
 import java.time.LocalDate
+import java.time.format.DateTimeFormatter
 
 class SignupViewModel : ViewModel() {
+
+    // 화면 상태 (프로젝트 내 정의된 타입 사용)
     var uiState by mutableStateOf(SignupUiState())
         private set
 
+    // 네트워크 진행/에러 상태
+    var loading by mutableStateOf(false)
+        private set
+    var errorMsg by mutableStateOf<String?>(null)
+        private set
+
+    // ---- step1 바인딩 ----
     fun onEmail(v: String)            { uiState = uiState.copy(email = v.trim()) }
     fun onPassword(v: String)         { uiState = uiState.copy(password = v) }
     fun onPasswordConfirm(v: String)  { uiState = uiState.copy(passwordConfirm = v) }
@@ -17,7 +37,7 @@ class SignupViewModel : ViewModel() {
     fun onMemberName(v: String)       { uiState = uiState.copy(memberName = v) }
     fun onPhone(v: String)            { uiState = uiState.copy(phoneNumber = v.filter { it.isDigit() }.take(11)) }
     fun onBirthday(d: LocalDate?)     { uiState = uiState.copy(birthday = d) }
-    fun onZipcode(v: String)          { uiState = uiState.copy(zipcode = v.take(5)) }
+    fun onZipcode(v: String)          { uiState = uiState.copy(zipcode = v.take(5)) } // 프로젝트 정책 유지
     fun onRoad(v: String)             { uiState = uiState.copy(roadAddress = v) }
     fun onDetail(v: String)           { uiState = uiState.copy(detailAddress = v) }
 
@@ -55,7 +75,7 @@ class SignupViewModel : ViewModel() {
         )
     }
 
-
+    // ---- 유효성 ----
     private val pwRegex = Regex("^(?=.{8,64}$)(?:(?=.*[A-Za-z])(?=.*\\d)|(?=.*[A-Za-z])(?=.*[^\\w\\s])|(?=.*\\d)(?=.*[^\\w\\s])).*$")
 
     val isValid: Boolean
@@ -72,4 +92,89 @@ class SignupViewModel : ViewModel() {
 
     val isStep2Valid: Boolean
         get() = uiState.skinType != null
+
+    // ---- 서버 DTO 매핑 ----
+    private fun toSignupAllRequest(): SignupAllRequest {
+        val bday = uiState.birthday?.format(DateTimeFormatter.ISO_DATE) // yyyy-MM-dd
+
+        val signup = SignupRequest(
+            email = uiState.email,
+            nickName = uiState.nickname,          // 서버 DTO 필드명: nickName (N 대문자)
+            memberName = uiState.memberName,
+            password = uiState.password,
+            zipcode = uiState.zipcode,
+            roadAddress = uiState.roadAddress,
+            detailAddress = uiState.detailAddress,
+            birthday = bday ?: "",                // @NotNull이므로 null이면 서버에서 400
+            phoneNumber = uiState.phoneNumber
+        )
+
+        val health = HealthInfoDto(
+            eyeHealth = if ("눈건강" in uiState.healthConcerns) 1 else 0,
+            fatigue = if ("만성피로" in uiState.healthConcerns) 1 else 0,
+            sleepStress = if ("수면/스트레스" in uiState.healthConcerns) 1 else 0,
+            immuneCare = if ("면역력" in uiState.healthConcerns) 1 else 0,
+            muscleHealth = if ("근력" in uiState.healthConcerns) 1 else 0,
+            gutHealth = if ("장건강" in uiState.healthConcerns) 1 else 0,
+            bloodCirculation = if ("혈액순환" in uiState.healthConcerns) 1 else 0
+        )
+
+        val hair = HairInfoDto(
+            hairLoss = if ("탈모" in uiState.scalpConcerns) 1 else 0,
+            damagedHair = if ("손상모" in uiState.scalpConcerns) 1 else 0,
+            scalpTrouble = if ("두피트러블" in uiState.scalpConcerns) 1 else 0,
+            dandruff = if ("비듬/각질" in uiState.scalpConcerns) 1 else 0
+        )
+
+        val skin = SkinInfoDto(
+            atopic = if ("아토피" in uiState.skinConcerns) 1 else 0,
+            acne = if ("여드름/민감성" in uiState.skinConcerns) 1 else 0,
+            whitening = if ("미백/잡티" in uiState.skinConcerns) 1 else 0,
+            sebum = if ("피지/블랙헤드" in uiState.skinConcerns) 1 else 0,
+            innerDryness = if ("속건조" in uiState.skinConcerns) 1 else 0,
+            wrinkles = if ("주름/탄력" in uiState.skinConcerns) 1 else 0,
+            enlargedPores = if ("모공" in uiState.skinConcerns) 1 else 0,
+            redness = if ("홍조" in uiState.skinConcerns) 1 else 0,
+            keratin = if ("각질" in uiState.skinConcerns) 1 else 0
+        )
+
+        return SignupAllRequest(
+            signup = signup,
+            concerns = ConcernRequest(health = health, hair = hair, skin = skin)
+        )
+    }
+
+    // ---- 가입 호출 (Step2의 "가입하기") ----
+    fun submitSignup(
+        onSuccess: (Long) -> Unit,
+        onError: (String) -> Unit
+    ) {
+        if (!isValid) {
+            onError("입력값을 확인해 주세요.")
+            return
+        }
+        if (!isStep2Valid) {
+            onError("피부 타입을 선택해 주세요.")
+            return
+        }
+
+        val api = RetrofitInstance.create(AuthApi::class.java)
+        val req = toSignupAllRequest()
+
+        viewModelScope.launch {
+            loading = true
+            errorMsg = null
+            try {
+                val res = api.join(req) // UtilResponse<SignupResponse>
+                val id = res.data?.id ?: error("가입 ID 없음")
+                onSuccess(id)
+            } catch (t: Throwable) {
+                val msg = t.message ?: "네트워크 오류"
+                errorMsg = msg
+                onError(msg)
+            } finally {
+                loading = false
+            }
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
#16 

## 📝 요약(Summary)
- 회원가입(3단계), 로그인 UI 구현
- 회원가입 및 로그인 API 연동
- 토큰/프로필 저장 구조 정리 및 적용
    - EncryptedSharedPreferences에 access/refresh 토큰 저장
    - 일반 SharedPreferences에 memberId/nickname/health 저장
 - 선택적 토큰 첨부 인터셉터 적용

## 💬 공유사항 to 리뷰어
- 회원가입은 연동했지만, 닉네임 및 이메일 중복체크 처리 전
- 회원가입 시, 주소 검색 기능 추가할 예정
