### PR TITLE
[FEAT] 마이페이지 남은부분 연동, 로그인시 삼성헬스 정보 저장

### DIFF
--- a/app/src/main/java/com/refit/app/data/auth/api/AuthApi.kt
+++ b/app/src/main/java/com/refit/app/data/auth/api/AuthApi.kt
@@ -7,6 +7,7 @@ import com.refit.app.data.auth.model.KakaoVerifyRequest
 import com.refit.app.data.auth.model.KakaoVerifyResponse
 import com.refit.app.data.auth.model.LoginRequest
 import com.refit.app.data.auth.model.LoginResponse
+import com.refit.app.data.auth.model.SamsungHealthSaveRequest
 import com.refit.app.data.auth.model.SignupAllRequest
 import com.refit.app.data.auth.model.SignupResponse
 import com.refit.app.data.auth.model.UpdateBasicRequest
@@ -52,4 +53,11 @@ interface AuthApi {
     @PUT("/auth/health")
     @Headers("Requires-Auth: true")
     suspend fun updateMyConcerns(@Body req: ConcernSummaryDto): UtilResponse<Void?>
+
+    @POST("/auth/health/samsung")
+    @Headers("Requires-Auth: true")
+    suspend fun saveSamsungHealth(
+        @Body req: SamsungHealthSaveRequest
+    ): UtilResponse<String>
+
 }

--- a/app/src/main/java/com/refit/app/data/auth/model/SamsungHealthSaveRequest.kt
+++ b/app/src/main/java/com/refit/app/data/auth/model/SamsungHealthSaveRequest.kt
@@ -1,0 +1,11 @@
+package com.refit.app.data.auth.model
+
+data class SamsungHealthSaveRequest(
+    val steps: Long?,
+    val totalKcal: Double?,
+    val bloodGlucoseMgdl: Double?,
+    val systolicMmhg: Double?,
+    val diastolicMmhg: Double?,
+    val intakeKcal: Double?,
+    val sleepMinutes: Long?
+)

--- a/app/src/main/java/com/refit/app/data/auth/model/SamsungHealthSaveResponse.kt
+++ b/app/src/main/java/com/refit/app/data/auth/model/SamsungHealthSaveResponse.kt
@@ -1,0 +1,5 @@
+package com.refit.app.data.auth.model
+
+data class SamsungHealthSaveResponse(
+    val message: String
+)

--- a/app/src/main/java/com/refit/app/data/auth/modelAndView/SamsungHealthViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/auth/modelAndView/SamsungHealthViewModel.kt
@@ -1,0 +1,29 @@
+package com.refit.app.data.auth.modelAndView
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.refit.app.data.auth.api.AuthApi
+import com.refit.app.data.auth.model.SamsungHealthSaveRequest
+import com.refit.app.network.RetrofitInstance
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class SamsungHealthViewModel : ViewModel() {
+
+    private val _message = MutableStateFlow<String?>(null)
+    val message: StateFlow<String?> = _message
+
+    private val authApi: AuthApi = RetrofitInstance.retrofit.create(AuthApi::class.java)
+
+    fun saveHealthInfo(request: SamsungHealthSaveRequest) {
+        viewModelScope.launch {
+            try {
+                val response = authApi.saveSamsungHealth(request)
+                _message.value = response.message
+            } catch (e: Exception) {
+                _message.value = "저장 실패: ${e.message}"
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/refit/app/data/cart/modelAndView/CartViewModelFactory.kt
+++ b/app/src/main/java/com/refit/app/data/cart/modelAndView/CartViewModelFactory.kt
@@ -1,0 +1,22 @@
+package com.refit.app.data.cart.modelAndView
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.refit.app.data.cart.repository.CartRepository
+
+class CartViewModelFactory(
+    private val repo: CartRepository,
+    private val badgeVm: CartBadgeViewModel? = null
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return when {
+            modelClass.isAssignableFrom(CartBadgeViewModel::class.java) -> {
+                CartBadgeViewModel(repo) as T
+            }
+            modelClass.isAssignableFrom(CartEditViewModel::class.java) -> {
+                CartEditViewModel(repo, badgeVm) as T
+            }
+            else -> throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+        }
+    }
+}

--- a/app/src/main/java/com/refit/app/data/combination/api/CombinationApi.kt
+++ b/app/src/main/java/com/refit/app/data/combination/api/CombinationApi.kt
@@ -1,8 +1,8 @@
-package com.refit.app.data.local.combination.api
+package com.refit.app.data.combination.api
 
-import com.refit.app.data.local.combination.model.CombinationLikeResponse
-import com.refit.app.data.local.combination.model.LikedCombinationRequest
-import com.refit.app.data.local.combination.model.CombinationsResponse
+import com.refit.app.data.combination.model.CombinationLikeResponse
+import com.refit.app.data.combination.model.LikedCombinationRequest
+import com.refit.app.data.combination.model.CombinationsResponse
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST

--- a/app/src/main/java/com/refit/app/data/combination/model/CombinationLikeResponse.kt
+++ b/app/src/main/java/com/refit/app/data/combination/model/CombinationLikeResponse.kt
@@ -1,4 +1,4 @@
-package com.refit.app.data.local.combination.model
+package com.refit.app.data.combination.model
 
 data class CombinationLikeResponse(
     val combinationId: Long,

--- a/app/src/main/java/com/refit/app/data/combination/model/CombinationsResponse.kt
+++ b/app/src/main/java/com/refit/app/data/combination/model/CombinationsResponse.kt
@@ -1,4 +1,4 @@
-package com.refit.app.data.local.combination.model
+package com.refit.app.data.combination.model
 
 data class CombinationsResponse(
     val combinations: List<CombinationDto>

--- a/app/src/main/java/com/refit/app/data/combination/model/LikedCombinationRequest.kt
+++ b/app/src/main/java/com/refit/app/data/combination/model/LikedCombinationRequest.kt
@@ -1,4 +1,4 @@
-package com.refit.app.data.local.combination.model
+package com.refit.app.data.combination.model
 
 data class LikedCombinationRequest(
     val ids: List<Long>

--- a/app/src/main/java/com/refit/app/data/combination/modelAndView/CombinationViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/combination/modelAndView/CombinationViewModel.kt
@@ -1,9 +1,9 @@
-package com.refit.app.data.local.combination.modelAndView
+package com.refit.app.data.combination.modelAndView
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.refit.app.data.local.combination.model.CombinationDto
-import com.refit.app.data.local.combination.repository.CombinationRepository
+import com.refit.app.data.combination.model.CombinationDto
+import com.refit.app.data.combination.repository.CombinationRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/refit/app/data/combination/repository/CombinationRepository.kt
+++ b/app/src/main/java/com/refit/app/data/combination/repository/CombinationRepository.kt
@@ -1,9 +1,9 @@
-package com.refit.app.data.local.combination.repository
+package com.refit.app.data.combination.repository
 
-import com.refit.app.data.local.combination.api.CombinationApi
-import com.refit.app.data.local.combination.model.CombinationLikeResponse
-import com.refit.app.data.local.combination.model.LikedCombinationRequest
-import com.refit.app.data.local.combination.model.CombinationsResponse
+import com.refit.app.data.combination.api.CombinationApi
+import com.refit.app.data.combination.model.CombinationLikeResponse
+import com.refit.app.data.combination.model.LikedCombinationRequest
+import com.refit.app.data.combination.model.CombinationsResponse
 import com.refit.app.network.RetrofitInstance
 
 class CombinationRepository(

--- a/app/src/main/java/com/refit/app/data/local/combination/api/CombinationApi.kt
+++ b/app/src/main/java/com/refit/app/data/local/combination/api/CombinationApi.kt
@@ -1,13 +1,23 @@
 package com.refit.app.data.local.combination.api
 
+import com.refit.app.data.local.combination.model.CombinationLikeResponse
 import com.refit.app.data.local.combination.model.LikedCombinationRequest
 import com.refit.app.data.local.combination.model.CombinationsResponse
 import retrofit2.http.Body
 import retrofit2.http.Headers
 import retrofit2.http.POST
+import retrofit2.http.Path
 
 interface CombinationApi {
     @POST("combinations/like")
     @Headers("Requires-Auth: true")
     suspend fun getLikedCombinations(@Body body: LikedCombinationRequest): CombinationsResponse
+
+    @POST("combinations/{combinationId}/like")
+    @Headers("Requires-Auth: true")
+    suspend fun likeCombination(@Path("combinationId") combinationId: Long): CombinationLikeResponse
+
+    @POST("combinations/{combinationId}/dislike")
+    @Headers("Requires-Auth: true")
+    suspend fun dislikeCombination(@Path("combinationId") combinationId: Long): CombinationLikeResponse
 }

--- a/app/src/main/java/com/refit/app/data/local/combination/model/CombinationLikeResponse.kt
+++ b/app/src/main/java/com/refit/app/data/local/combination/model/CombinationLikeResponse.kt
@@ -1,0 +1,6 @@
+package com.refit.app.data.local.combination.model
+
+data class CombinationLikeResponse(
+    val combinationId: Long,
+    val message: String
+)

--- a/app/src/main/java/com/refit/app/data/local/combination/modelAndView/CombinationViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/local/combination/modelAndView/CombinationViewModel.kt
@@ -2,8 +2,8 @@ package com.refit.app.data.local.combination.modelAndView
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.refit.app.data.local.combination.repository.CombinationRepository
 import com.refit.app.data.local.combination.model.CombinationDto
+import com.refit.app.data.local.combination.repository.CombinationRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -11,7 +11,9 @@ import kotlinx.coroutines.launch
 data class CombinationUiState(
     val combinations: List<CombinationDto> = emptyList(),
     val isLoading: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
+    val message: String? = null,
+    val isProcessing: Boolean = false  // 요청 중복 방지 flag
 )
 
 class LikedCombinationViewModel(
@@ -21,13 +23,56 @@ class LikedCombinationViewModel(
     private val _state = MutableStateFlow(CombinationUiState())
     val state: StateFlow<CombinationUiState> = _state
 
+    /** 찜한 조합 불러오기 */
     fun loadLikedCombinations(ids: Set<Long>) {
         viewModelScope.launch {
-            _state.value = CombinationUiState(isLoading = true)
+            _state.value = _state.value.copy(isLoading = true, error = null, message = null)
             val result = repo.getLikedCombinations(ids.toList())
             _state.value = result.fold(
                 onSuccess = { CombinationUiState(combinations = it.combinations) },
                 onFailure = { CombinationUiState(error = it.message) }
+            )
+        }
+    }
+
+    /** 좋아요 등록 */
+    fun likeCombination(combinationId: Long) {
+        if (_state.value.isProcessing) return
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isProcessing = true)
+            val result = repo.likeCombination(combinationId)
+            _state.value = result.fold(
+                onSuccess = { res ->
+                    val updatedList = _state.value.combinations.map {
+                        if (it.combinationId == combinationId) it.copy(likes = (it.likes ?: 0) + 1)
+                        else it
+                    }
+                    _state.value.copy(combinations = updatedList, message = res.message, isProcessing = false)
+                },
+                onFailure = {
+                    _state.value.copy(error = it.message, isProcessing = false)
+                }
+            )
+        }
+    }
+
+    /** 좋아요 해제 */
+    fun dislikeCombination(combinationId: Long) {
+        if (_state.value.isProcessing) return
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isProcessing = true)
+            val result = repo.dislikeCombination(combinationId)
+            _state.value = result.fold(
+                onSuccess = { res ->
+                    val updatedList = _state.value.combinations.map {
+                        if (it.combinationId == combinationId) it.copy(likes = maxOf((it.likes ?: 0) - 1, 0))
+                        else it
+                    }
+                    _state.value.copy(combinations = updatedList, message = res.message, isProcessing = false)
+                },
+                onFailure = {
+                    _state.value.copy(error = it.message, isProcessing = false)
+                }
             )
         }
     }

--- a/app/src/main/java/com/refit/app/data/local/combination/repository/CombinationRepository.kt
+++ b/app/src/main/java/com/refit/app/data/local/combination/repository/CombinationRepository.kt
@@ -1,6 +1,7 @@
 package com.refit.app.data.local.combination.repository
 
 import com.refit.app.data.local.combination.api.CombinationApi
+import com.refit.app.data.local.combination.model.CombinationLikeResponse
 import com.refit.app.data.local.combination.model.LikedCombinationRequest
 import com.refit.app.data.local.combination.model.CombinationsResponse
 import com.refit.app.network.RetrofitInstance
@@ -10,5 +11,13 @@ class CombinationRepository(
 ) {
     suspend fun getLikedCombinations(ids: List<Long>): Result<CombinationsResponse> = runCatching {
         api.getLikedCombinations(LikedCombinationRequest(ids))
+    }
+
+    suspend fun likeCombination(combinationId: Long): Result<CombinationLikeResponse> = runCatching {
+        api.likeCombination(combinationId)
+    }
+
+    suspend fun dislikeCombination(combinationId: Long): Result<CombinationLikeResponse> = runCatching {
+        api.dislikeCombination(combinationId)
     }
 }

--- a/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
+++ b/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
@@ -1,6 +1,6 @@
 package com.refit.app.data.me.api
 
-import com.refit.app.data.local.combination.model.CombinationsResponse
+import com.refit.app.data.combination.model.CombinationsResponse
 import com.refit.app.data.me.model.LikeRequest
 import com.refit.app.data.me.model.LikeResponse
 import com.refit.app.data.me.model.OrdersResponse

--- a/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
+++ b/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
@@ -5,6 +5,7 @@ import com.refit.app.data.me.model.LikeRequest
 import com.refit.app.data.me.model.LikeResponse
 import com.refit.app.data.me.model.OrdersResponse
 import com.refit.app.data.me.model.ProfileImageResponse
+import com.refit.app.data.me.model.UpdateOrderStatusResponse
 import okhttp3.MultipartBody
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -12,6 +13,7 @@ import retrofit2.http.Headers
 import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.Part
+import retrofit2.http.Path
 
 interface MeApi {
     @POST("products/like")
@@ -32,5 +34,13 @@ interface MeApi {
     suspend fun updateProfileImage(
         @Part profileImage: MultipartBody.Part
     ): ProfileImageResponse
+
+    @POST("/orders/{orderItemId}/exchange")
+    @Headers("Requires-Auth: true")
+    suspend fun requestExchange(@Path("orderItemId") orderItemId: Long): UpdateOrderStatusResponse
+
+    @POST("/orders/{orderItemId}/return")
+    @Headers("Requires-Auth: true")
+    suspend fun requestReturn(@Path("orderItemId") orderItemId: Long): UpdateOrderStatusResponse
 
 }

--- a/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
+++ b/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
@@ -4,10 +4,14 @@ import com.refit.app.data.local.combination.model.CombinationsResponse
 import com.refit.app.data.me.model.LikeRequest
 import com.refit.app.data.me.model.LikeResponse
 import com.refit.app.data.me.model.OrdersResponse
+import com.refit.app.data.me.model.ProfileImageResponse
+import okhttp3.MultipartBody
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Headers
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
 
 interface MeApi {
     @POST("products/like")
@@ -22,4 +26,10 @@ interface MeApi {
     @Headers("Requires-Auth: true")
     suspend fun getCreatedCombinations(): CombinationsResponse
 
+    @Multipart
+    @POST("/me/profile/image/update")
+    @Headers("Requires-Auth: true")
+    suspend fun updateProfileImage(
+        @Part profileImage: MultipartBody.Part
+    ): ProfileImageResponse
 }

--- a/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
+++ b/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
@@ -30,6 +30,6 @@ interface MeApi {
     @POST("/me/profile/image/update")
     @Headers("Requires-Auth: true")
     suspend fun updateProfileImage(
-        @Part profileImage: MultipartBody.Part
+        @Part("profileImage") profileImage: MultipartBody.Part
     ): ProfileImageResponse
 }

--- a/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
+++ b/app/src/main/java/com/refit/app/data/me/api/MeApi.kt
@@ -30,6 +30,7 @@ interface MeApi {
     @POST("/me/profile/image/update")
     @Headers("Requires-Auth: true")
     suspend fun updateProfileImage(
-        @Part("profileImage") profileImage: MultipartBody.Part
+        @Part profileImage: MultipartBody.Part
     ): ProfileImageResponse
+
 }

--- a/app/src/main/java/com/refit/app/data/me/model/OrdersResponse.kt
+++ b/app/src/main/java/com/refit/app/data/me/model/OrdersResponse.kt
@@ -2,6 +2,7 @@ package com.refit.app.data.me.model
 
 data class OrderItemDto(
     val orderItemId: Long,
+    val productId: Long,
     val orderNumber: String,
     val productName: String,
     val thumbnailUrl: String,

--- a/app/src/main/java/com/refit/app/data/me/model/ProfileImageResponse.kt
+++ b/app/src/main/java/com/refit/app/data/me/model/ProfileImageResponse.kt
@@ -1,0 +1,6 @@
+package com.refit.app.data.me.model
+
+data class ProfileImageResponse(
+    val profileUrl: String,
+    val message: String
+)

--- a/app/src/main/java/com/refit/app/data/me/model/UpdateOrderStatusResponse.kt
+++ b/app/src/main/java/com/refit/app/data/me/model/UpdateOrderStatusResponse.kt
@@ -1,0 +1,5 @@
+package com.refit.app.data.me.model
+
+data class UpdateOrderStatusResponse(
+    val message: String
+)

--- a/app/src/main/java/com/refit/app/data/me/modelAndView/MyCombinationViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/me/modelAndView/MyCombinationViewModel.kt
@@ -3,7 +3,7 @@ package com.refit.app.data.me.modelAndView
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.refit.app.data.local.combination.model.CombinationDto
+import com.refit.app.data.combination.model.CombinationDto
 import com.refit.app.data.me.repository.MeRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/refit/app/data/me/modelAndView/OrderViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/me/modelAndView/OrderViewModel.kt
@@ -3,6 +3,7 @@ package com.refit.app.data.me.modelAndView
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.refit.app.data.me.model.OrdersResponse
+import com.refit.app.data.me.model.UpdateOrderStatusResponse
 import com.refit.app.data.me.repository.MeRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -12,7 +13,8 @@ import kotlinx.coroutines.launch
 data class OrderUiState(
     val orders: OrdersResponse? = null,
     val isLoading: Boolean = false,
-    val error: String? = null
+    val error: String? = null,
+    val actionMessage: String? = null
 )
 
 class OrderViewModel(
@@ -24,7 +26,7 @@ class OrderViewModel(
 
     fun loadOrders() {
         viewModelScope.launch {
-            _state.value = _state.value.copy(isLoading = true, error = null)
+            _state.value = _state.value.copy(isLoading = true, error = null, actionMessage = null)
             val result = repo.getOrders()
             _state.value = result.fold(
                 onSuccess = { response ->
@@ -41,5 +43,64 @@ class OrderViewModel(
             )
         }
     }
-}
 
+    // 교환 신청
+    fun requestExchange(orderItemId: Long) {
+        viewModelScope.launch {
+            val result = repo.requestExchange(orderItemId)
+            _state.value = result.fold(
+                onSuccess = { res: UpdateOrderStatusResponse ->
+                    val currentOrders = _state.value.orders
+                    val updatedOrders = currentOrders?.copy(
+                        recentOrder = currentOrders.recentOrder.map { order ->
+                            order.copy(
+                                items = order.items.map { item ->
+                                    if (item.orderItemId == orderItemId) {
+                                        item.copy(status = 4) // 교환 신청중
+                                    } else item
+                                }
+                            )
+                        }
+                    )
+                    _state.value.copy(
+                        orders = updatedOrders,
+                        actionMessage = res.message
+                    )
+                },
+                onFailure = {
+                    _state.value.copy(actionMessage = "교환 신청 실패: ${it.message}")
+                }
+            )
+        }
+    }
+
+    // 반품 신청
+    fun requestReturn(orderItemId: Long) {
+        viewModelScope.launch {
+            val result = repo.requestReturn(orderItemId)
+            _state.value = result.fold(
+                onSuccess = { res: UpdateOrderStatusResponse ->
+                    val currentOrders = _state.value.orders
+                    val updatedOrders = currentOrders?.copy(
+                        recentOrder = currentOrders.recentOrder.map { order ->
+                            order.copy(
+                                items = order.items.map { item ->
+                                    if (item.orderItemId == orderItemId) {
+                                        item.copy(status = 6) // 반품 신청중
+                                    } else item
+                                }
+                            )
+                        }
+                    )
+                    _state.value.copy(
+                        orders = updatedOrders,
+                        actionMessage = res.message
+                    )
+                },
+                onFailure = {
+                    _state.value.copy(actionMessage = "반품 신청 실패: ${it.message}")
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/refit/app/data/me/modelAndView/ProfileImageViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/me/modelAndView/ProfileImageViewModel.kt
@@ -1,0 +1,35 @@
+package com.refit.app.data.me.modelAndView
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.refit.app.data.me.api.MeApi
+import com.refit.app.data.me.model.ProfileImageResponse
+import com.refit.app.network.RetrofitInstance
+import com.refit.app.network.UserPrefs
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import okhttp3.MultipartBody
+
+class ProfileImageViewModel : ViewModel() {
+
+    private val meApi: MeApi = RetrofitInstance.retrofit.create(MeApi::class.java)
+
+    private val _profileUrl = MutableStateFlow<String?>(null)
+    val profileUrl: StateFlow<String?> = _profileUrl
+
+    fun updateProfileImage(filePart: MultipartBody.Part) {
+        viewModelScope.launch {
+            try {
+                val response: ProfileImageResponse = meApi.updateProfileImage(filePart)
+                _profileUrl.value = response.profileUrl
+
+                UserPrefs.setProfileUrl(response.profileUrl)
+
+            } catch (e: Exception) {
+                _profileUrl.value = null
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/refit/app/data/me/repository/MeRepository.kt
+++ b/app/src/main/java/com/refit/app/data/me/repository/MeRepository.kt
@@ -1,7 +1,7 @@
 package com.refit.app.data.me.repository
 
 import com.refit.app.data.me.api.MeApi
-import com.refit.app.data.local.combination.model.CombinationsResponse
+import com.refit.app.data.combination.model.CombinationsResponse
 import com.refit.app.data.me.model.LikeProductDto
 import com.refit.app.data.me.model.LikeRequest
 import com.refit.app.data.me.model.OrdersResponse

--- a/app/src/main/java/com/refit/app/data/me/repository/MeRepository.kt
+++ b/app/src/main/java/com/refit/app/data/me/repository/MeRepository.kt
@@ -5,6 +5,7 @@ import com.refit.app.data.local.combination.model.CombinationsResponse
 import com.refit.app.data.me.model.LikeProductDto
 import com.refit.app.data.me.model.LikeRequest
 import com.refit.app.data.me.model.OrdersResponse
+import com.refit.app.data.me.model.UpdateOrderStatusResponse
 import com.refit.app.data.product.model.Product
 import com.refit.app.network.RetrofitInstance
 
@@ -19,19 +20,32 @@ private fun LikeProductDto.toDomain() = Product(
 )
 
 class MeRepository(
-    private val api: MeApi = RetrofitInstance.create(MeApi::class.java)
+    private val meApi: MeApi = RetrofitInstance.create(MeApi::class.java),
 ) {
+    // 찜한 상품 불러오기
     suspend fun getLikedProducts(ids: Set<Long>): Result<List<Product>> = runCatching {
         if (ids.isEmpty()) return@runCatching emptyList<Product>()
-        val res = api.getLikedProducts(LikeRequest(ids.toList()))
+        val res = meApi.getLikedProducts(LikeRequest(ids.toList()))
         res.items.map { it.toDomain() }
     }
 
+    // 주문 내역 불러오기
     suspend fun getOrders(): Result<OrdersResponse> = runCatching {
-        api.getOrders()
+        meApi.getOrders()
     }
 
+    // 내가 만든 조합 불러오기
     suspend fun getCreatedCombinations(): Result<CombinationsResponse> = runCatching {
-        api.getCreatedCombinations()
+        meApi.getCreatedCombinations()
+    }
+
+    // 교환 신청
+    suspend fun requestExchange(orderItemId: Long): Result<UpdateOrderStatusResponse> = runCatching {
+        meApi.requestExchange(orderItemId)
+    }
+
+    // 반품 신청
+    suspend fun requestReturn(orderItemId: Long): Result<UpdateOrderStatusResponse> = runCatching {
+        meApi.requestReturn(orderItemId)
     }
 }

--- a/app/src/main/java/com/refit/app/network/UserPrefs.kt
+++ b/app/src/main/java/com/refit/app/network/UserPrefs.kt
@@ -14,6 +14,9 @@ object UserPrefs {
     private const val KEY_HEALTH    = "health_json"
     private const val KEY_HAIR      = "hair_json"
     private const val KEY_SKIN      = "skin_json"
+    private const val KEY_PROFILE_URL = "profile_url"
+    private const val DEFAULT_PROFILE_URL =
+        "https://refit-s3.s3.ap-northeast-2.amazonaws.com/default_profile/default.png"
 
     private lateinit var prefs: SharedPreferences
     private val gson by lazy { Gson() }
@@ -86,5 +89,16 @@ object UserPrefs {
     fun setSkin(skin: SkinInfoDto?) {
         prefs.edit().putString(KEY_SKIN, skin?.let { gson.toJson(it) } ?: "").apply()
     }
+
+    fun setProfileUrl(url: String?) {
+        if (!::prefs.isInitialized) return
+        prefs.edit().putString(KEY_PROFILE_URL, url ?: DEFAULT_PROFILE_URL).apply()
+    }
+
+    fun getProfileUrl(): String =
+        if (!::prefs.isInitialized) DEFAULT_PROFILE_URL
+        else prefs.getString(KEY_PROFILE_URL, null)
+            ?.takeIf { it.isNotBlank() }
+            ?: DEFAULT_PROFILE_URL
 
 }

--- a/app/src/main/java/com/refit/app/ui/composable/combination/CombinationCard.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/combination/CombinationCard.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
-import com.refit.app.data.local.combination.model.CombinationDto
+import com.refit.app.data.combination.model.CombinationDto
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
 

--- a/app/src/main/java/com/refit/app/ui/composable/home/GreetingCard.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/home/GreetingCard.kt
@@ -25,9 +25,12 @@ import androidx.compose.ui.unit.sp
 import com.refit.app.R
 import com.refit.app.ui.theme.MainPurple
 import androidx.compose.foundation.border
+import coil.compose.AsyncImage
+import com.refit.app.network.UserPrefs
 
 @Composable
 fun GreetingCard(nickname: String, tags: List<String>) {
+    val profileUrl = UserPrefs.getProfileUrl()
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -42,8 +45,8 @@ fun GreetingCard(nickname: String, tags: List<String>) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             // 프사
-            Image(
-                painter = painterResource(R.drawable.jellbbo_default),
+            AsyncImage(
+                model = profileUrl,
                 contentDescription = null,
                 modifier = Modifier
                     .size(72.dp)

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/CustomRadioButton.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/CustomRadioButton.kt
@@ -1,0 +1,44 @@
+package com.refit.app.ui.composable.mypage
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.refit.app.ui.theme.MainPurple
+
+@Composable
+fun CustomRadioButton(
+    selected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .size(20.dp)
+            .clip(RoundedCornerShape(50))
+            .border(
+                width = 2.dp,
+                color = if (selected) MainPurple else Color.Gray,
+                shape = RoundedCornerShape(50)
+            )
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        if (selected) {
+            Box(
+                modifier = Modifier
+                    .size(10.dp)
+                    .clip(RoundedCornerShape(50))
+                    .background(MainPurple)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/ExchangeReturnReasonDialog.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/ExchangeReturnReasonDialog.kt
@@ -1,0 +1,230 @@
+package com.refit.app.ui.composable.mypage
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.refit.app.ui.theme.MainPurple
+import com.refit.app.ui.theme.Pretendard
+
+@Composable
+fun ExchangeReturnReasonDialog(
+    orderItemId: Long,
+    onDismiss: () -> Unit,
+    onConfirmExchange: (Long) -> Unit,
+    onConfirmReturn: (Long) -> Unit
+) {
+    var step by remember { mutableStateOf(1) }
+    var selectedReason by remember { mutableStateOf<String?>(null) }
+    var selectedAction by remember { mutableStateOf<String?>(null) }
+
+    val categories = listOf(
+        "단순 변심" to listOf("상품이 마음에 들지 않음"),
+        "배송 문제" to listOf(
+            "배송된 장소에 박스가 분실됨",
+            "다른 주소로 배송됨"
+        ),
+        "상품 문제" to listOf(
+            "상품 내 구성품 부재",
+            "상품이 설명과 다름",
+            "다른 상품이 배송됨",
+            "상품이 파손됨"
+        )
+    )
+
+    Dialog(onDismissRequest = { onDismiss() }) {
+        Surface(
+            shape = RoundedCornerShape(16.dp),
+            color = Color.White,
+            tonalElevation = 6.dp,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .border(1.dp, Color.Black, RoundedCornerShape(16.dp))
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .verticalScroll(rememberScrollState())
+            ) {
+                // 상단 진행 단계 ProgressBar
+                LinearProgressIndicator(
+                    progress = { if (step == 1) 0.5f else 1f },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(8.dp)
+                        .clipToBounds(),
+                    color = MainPurple,
+                    trackColor = Color(0xFFEAEAEA),
+                    strokeCap = StrokeCap.Butt
+                )
+
+                Column(
+                    modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                ) {
+                    // 타이틀
+                    Text(
+                        text = "교환 / 반품 신청",
+                        fontFamily = Pretendard,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 20.sp
+                    )
+
+                    HorizontalDivider()
+
+                    // 사유 선택
+                    if (step == 1) {
+                        Text(
+                            "어떤 문제가 있나요?",
+                            fontFamily = Pretendard,
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 16.sp,
+                            modifier = Modifier.padding(bottom = 14.dp)
+                        )
+                        categories.forEachIndexed { idx, (category, reasons) ->
+                            Text(
+                                text = category,
+                                fontFamily = Pretendard,
+                                fontWeight = FontWeight.SemiBold,
+                                color = Color.Gray,
+                                fontSize = 14.sp,
+                                modifier = Modifier.padding(vertical = 0.dp)
+                            )
+                            reasons.forEach { reason ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 2.dp)
+                                        .clickable { selectedReason = reason }
+                                ) {
+                                    CustomRadioButton(
+                                        selected = selectedReason == reason,
+                                        onClick = { selectedReason = reason }
+                                    )
+                                    Spacer(Modifier.width(8.dp))
+                                    Text(
+                                        reason,
+                                        fontFamily = Pretendard,
+                                        fontSize = 14.sp,
+                                        color = if (selectedReason == reason) MainPurple else Color.Black
+                                    )
+                                }
+                            }
+                            if (idx < categories.lastIndex) HorizontalDivider(Modifier.padding(vertical = 4.dp))
+                        }
+                    }
+
+                    // 해결 방법 선택
+                    if (step == 2) {
+                        Text(
+                            "해결 방법을 선택해주세요",
+                            fontFamily = Pretendard,
+                            fontWeight = FontWeight.Medium,
+                            fontSize = 16.sp,
+                            modifier = Modifier.padding(bottom = 14.dp)
+                        )
+                        listOf("교환 신청" to "exchange", "반품 신청" to "return").forEach { (label, value) ->
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 2.dp)
+                                    .clickable { selectedAction = value }
+                            ) {
+                                CustomRadioButton(
+                                    selected = selectedAction == value,
+                                    onClick = { selectedAction = value }
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                Text(
+                                    label,
+                                    fontFamily = Pretendard,
+                                    fontSize = 15.sp,
+                                    color = if (selectedAction == value) MainPurple else Color.Black
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(Modifier.height(4.dp))
+
+                    // 하단 버튼
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        // 취소 버튼
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(42.dp)
+                                .background(Color.White, shape = RoundedCornerShape(8.dp))
+                                .border(
+                                    width = 1.dp,
+                                    color = Color(0xFFCCCCCC),
+                                    shape = RoundedCornerShape(8.dp)
+                                )
+                                .clickable { onDismiss() },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "취소",
+                                fontFamily = Pretendard,
+                                fontSize = 14.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = Color(0xFF666666)
+                            )
+                        }
+
+                        // 다음 단계 / 신청 완료 버튼
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(42.dp)
+                                .background(
+                                    if (if (step == 1) selectedReason != null else selectedAction != null)
+                                        MainPurple else Color(0xFFE0E0E0),
+                                    shape = RoundedCornerShape(8.dp)
+                                )
+                                .clickable(
+                                    enabled = if (step == 1) selectedReason != null else selectedAction != null
+                                ) {
+                                    if (step == 1) step = 2
+                                    else {
+                                        if (selectedAction == "exchange") onConfirmExchange(orderItemId)
+                                        if (selectedAction == "return") onConfirmReturn(orderItemId)
+                                        onDismiss()
+                                    }
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = if (step == 1) "다음 단계" else "신청 완료",
+                                fontFamily = Pretendard,
+                                fontSize = 15.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = Color.White
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/ExchangeReturnReasonDialog.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/ExchangeReturnReasonDialog.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import com.refit.app.ui.theme.LightPurple
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
 
@@ -54,7 +55,7 @@ fun ExchangeReturnReasonDialog(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = 16.dp, vertical = 8.dp)
-                .border(1.dp, Color.Black, RoundedCornerShape(16.dp))
+                .border(3.dp, Color.Black, RoundedCornerShape(16.dp))
         ) {
             Column(
                 modifier = Modifier
@@ -66,7 +67,7 @@ fun ExchangeReturnReasonDialog(
                     progress = { if (step == 1) 0.5f else 1f },
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(8.dp)
+                        .height(10.dp)
                         .clipToBounds(),
                     color = MainPurple,
                     trackColor = Color(0xFFEAEAEA),

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/MypageProfileCard.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/MypageProfileCard.kt
@@ -64,7 +64,7 @@ fun MypageProfileCard(
             val file = FileUtils.getFileFromUri(context, it)
             file?.let { f ->
                 val requestFile = f.asRequestBody("image/*".toMediaTypeOrNull())
-                val body = MultipartBody.Part.createFormData("file", f.name, requestFile)
+                val body = MultipartBody.Part.createFormData("profileImage", f.name, requestFile)
                 vm.updateProfileImage(body)
             } ?: run {
                 // 파일 변환 실패 처리

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/MypageProfileCard.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/MypageProfileCard.kt
@@ -1,5 +1,8 @@
 package com.refit.app.ui.composable.mypage
 
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -13,27 +16,62 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.refit.app.R
+import com.refit.app.data.me.modelAndView.ProfileImageViewModel
+import com.refit.app.network.UserPrefs
 import com.refit.app.ui.composable.home.HashtagChip
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
+import androidx.compose.runtime.getValue
+import coil.compose.AsyncImage
+import com.refit.app.util.file.FileUtils
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody.Companion.asRequestBody
+
 
 @Composable
 fun MypageProfileCard(
     nickname: String,
     tags: List<String>,
     onEditClick: () -> Unit = {},
-    onArrowClick: () -> Unit = {}
+    onArrowClick: () -> Unit = {},
+    vm: ProfileImageViewModel = viewModel()
 ) {
+    val context = LocalContext.current
+    val profileUrl by vm.profileUrl.collectAsState()
+
+    val savedUrl = UserPrefs.getProfileUrl()
+    val finalUrl = profileUrl ?: savedUrl
+
+    // 갤러리/카메라 런처 준비
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent()
+    ) { uri ->
+        uri?.let {
+            val file = FileUtils.getFileFromUri(context, it)
+            file?.let { f ->
+                val requestFile = f.asRequestBody("image/*".toMediaTypeOrNull())
+                val body = MultipartBody.Part.createFormData("file", f.name, requestFile)
+                vm.updateProfileImage(body)
+            } ?: run {
+                // 파일 변환 실패 처리
+                Log.e("Profile", "Failed to convert URI to File")
+            }
+        }
+    }
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -48,14 +86,15 @@ fun MypageProfileCard(
             verticalAlignment = Alignment.CenterVertically
         ) {
             // 프로필 이미지
-            Image(
-                painter = painterResource(R.drawable.jellbbo_default),
+            AsyncImage(
+                model = finalUrl,
                 contentDescription = null,
                 modifier = Modifier
                     .size(80.dp)
                     .clip(CircleShape)
-                    .border(2.dp, MainPurple, CircleShape) // MainPurple 테두리
-                    .background(Color.White),
+                    .border(2.dp, MainPurple, CircleShape)
+                    .background(Color.White)
+                    .clickable { launcher.launch("image/*") },
                 contentScale = ContentScale.Crop
             )
             Spacer(Modifier.width(12.dp))

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/MypageProfileCard.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/MypageProfileCard.kt
@@ -85,18 +85,36 @@ fun MypageProfileCard(
             modifier = Modifier.padding(20.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // 프로필 이미지
-            AsyncImage(
-                model = finalUrl,
-                contentDescription = null,
+            // 프로필 이미지 박스
+            Box(
                 modifier = Modifier
                     .size(80.dp)
-                    .clip(CircleShape)
-                    .border(2.dp, MainPurple, CircleShape)
-                    .background(Color.White)
                     .clickable { launcher.launch("image/*") },
-                contentScale = ContentScale.Crop
-            )
+                contentAlignment = Alignment.BottomEnd
+            ) {
+                // 프사 부분
+                AsyncImage(
+                    model = finalUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(CircleShape)
+                        .border(2.dp, MainPurple, CircleShape)
+                        .background(Color.White),
+                    contentScale = ContentScale.Crop
+                )
+
+                Icon(
+                    painter = painterResource(R.drawable.ic_camera),
+                    contentDescription = "프로필 변경",
+                    tint = Color.Unspecified,
+                    modifier = Modifier
+                        .size(24.dp)
+                        .background(Color.White, CircleShape)
+                        .border(1.dp, Color.Black, CircleShape)
+                        .padding(4.dp)
+                )
+            }
             Spacer(Modifier.width(12.dp))
 
             // 오른쪽 정보

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/OrderItemRow.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/OrderItemRow.kt
@@ -1,16 +1,14 @@
 package com.refit.app.ui.composable.mypage
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -20,11 +18,14 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
 import com.refit.app.data.me.model.OrderItemDto
+import com.refit.app.data.me.modelAndView.OrderViewModel
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 
 @Composable
-fun OrderItemRow(item: OrderItemDto) {
+fun OrderItemRow(item: OrderItemDto, vm: OrderViewModel) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -36,6 +37,10 @@ fun OrderItemRow(item: OrderItemDto) {
             1 -> "배송중"
             2 -> "배송완료"
             3 -> "취소완료"
+            4 -> "교환 신청중"
+            5 -> "교환 완료"
+            6 -> "반품 신청중"
+            7 -> "반품 완료"
             else -> "알수없음"
         }
 
@@ -109,12 +114,23 @@ fun OrderItemRow(item: OrderItemDto) {
 
                 // 교환/반품 버튼 (배송완료일 때만)
                 if (item.status == 2) {
-                    Spacer(Modifier.height(10.dp))
+                    var showDialog by remember { mutableStateOf(false) }
+
+                    if (showDialog) {
+                        ExchangeReturnReasonDialog(
+                            orderItemId = item.orderItemId,
+                            onDismiss = { showDialog = false },
+                            onConfirmExchange = { vm.requestExchange(it) },
+                            onConfirmReturn = { vm.requestReturn(it) }
+                        )
+                    }
+
                     MyOrderActionButton(
-                        text = "교환/반품 신청",
+                        text = "교환/반품",
                         modifier = Modifier
                             .width(80.dp)
-                            .height(24.dp)
+                            .height(24.dp),
+                        onClick = { showDialog = true }
                     )
                 }
             }

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/OrderItemRow.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/OrderItemRow.kt
@@ -23,9 +23,10 @@ import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import com.refit.app.data.cart.modelAndView.CartEditViewModel
 
 @Composable
-fun OrderItemRow(item: OrderItemDto, vm: OrderViewModel) {
+fun OrderItemRow(item: OrderItemDto, vm: OrderViewModel, cartVm: CartEditViewModel) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -135,7 +136,11 @@ fun OrderItemRow(item: OrderItemDto, vm: OrderViewModel) {
                 }
             }
 
-            IconButton(onClick = { /* 장바구니 담기 */ }) {
+            IconButton(onClick = {
+                cartVm.addOne(item.productId, 1)
+            },
+                modifier = Modifier.align(Alignment.CenterVertically)
+            ) {
                 Icon(
                     imageVector = Icons.Default.ShoppingCart,
                     tint = MainPurple,

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
@@ -24,6 +24,7 @@ import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import com.refit.app.data.cart.modelAndView.CartEditViewModel
 import com.refit.app.data.me.modelAndView.OrderViewModel
 
 
@@ -31,7 +32,8 @@ import com.refit.app.data.me.modelAndView.OrderViewModel
 fun RecentOrderSection(
     order: OrderResponse,
     onClickAll: () -> Unit,
-    vm: OrderViewModel
+    vm: OrderViewModel,
+    cartVm: CartEditViewModel
 ) {
     Column(
         modifier = Modifier
@@ -188,7 +190,9 @@ fun RecentOrderSection(
                             }
                         }
                         IconButton(
-                            onClick = { },
+                            onClick = {
+                                cartVm.addOne(item.productId, 1)
+                            },
                             modifier = Modifier.align(Alignment.CenterVertically)
                         ) {
                             Icon(

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
@@ -7,6 +7,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ShoppingCart
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -20,11 +22,16 @@ import com.refit.app.data.me.model.OrderResponse
 import com.refit.app.ui.theme.LightPurple
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import com.refit.app.data.me.modelAndView.OrderViewModel
+
 
 @Composable
 fun RecentOrderSection(
     order: OrderResponse,
-    onClickAll: () -> Unit
+    onClickAll: () -> Unit,
+    vm: OrderViewModel
 ) {
     Column(
         modifier = Modifier
@@ -101,6 +108,10 @@ fun RecentOrderSection(
                                         1 -> "배송중"
                                         2 -> "배송완료"
                                         3 -> "취소완료"
+                                        4 -> "교환 신청중"
+                                        5 -> "교환 완료"
+                                        6 -> "반품 신청중"
+                                        7 -> "반품 완료"
                                         else -> "알수없음"
                                     },
                                     color = MainPurple,
@@ -154,12 +165,24 @@ fun RecentOrderSection(
 
                                 // 배송완료 → 교환/반품 신청 버튼
                                 if (item.status == 2) {
+                                    var showDialog by remember { mutableStateOf(false) }
+
+                                    if (showDialog) {
+                                        ExchangeReturnReasonDialog(
+                                            orderItemId = item.orderItemId,
+                                            onDismiss = { showDialog = false },
+                                            onConfirmExchange = { vm.requestExchange(it) },
+                                            onConfirmReturn = { vm.requestReturn(it) }
+                                        )
+                                    }
+
                                     MyOrderActionButton(
-                                        text = "교환/반품 신청",
+                                        text = "교환/반품",
                                         modifier = Modifier
                                             .width(90.dp)
                                             .height(28.dp)
-                                            .padding(top = 6.dp)
+                                            .padding(top = 6.dp),
+                                        onClick = { showDialog = true }
                                     )
                                 }
                             }

--- a/app/src/main/java/com/refit/app/ui/screen/LikedCombinationListScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/LikedCombinationListScreen.kt
@@ -52,7 +52,17 @@ fun LikedCombinationListScreen(vm: LikedCombinationViewModel = viewModel()) {
                         combination = combination,
                         isSaved = wishedIds.contains(combination.combinationId),
                         onToggleSave = { id ->
-                            scope.launch { wishStore.toggle(id) }
+                            scope.launch {
+                                if (wishedIds.contains(id)) {
+                                    // 이미 저장된 상태라면 → 해제
+                                    vm.dislikeCombination(id)
+                                } else {
+                                    // 저장되지 않은 상태라면 → 등록
+                                    vm.likeCombination(id)
+                                }
+
+                                wishStore.toggle(id)
+                            }
                         },
                         showSaveButton = true
                     )

--- a/app/src/main/java/com/refit/app/ui/screen/LikedCombinationListScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/LikedCombinationListScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.refit.app.data.local.wish.WishStore
-import com.refit.app.data.local.combination.modelAndView.LikedCombinationViewModel
+import com.refit.app.data.combination.modelAndView.LikedCombinationViewModel
 import com.refit.app.ui.composable.combination.CombinationCard
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/com/refit/app/ui/screen/MypageScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/MypageScreen.kt
@@ -49,7 +49,8 @@ fun MypageScreen(navController: NavController, vm: OrderViewModel = viewModel())
             ?.let { latestOrder ->
                 RecentOrderSection(
                     order = latestOrder,
-                    onClickAll = { navController.navigate("orders") }
+                    onClickAll = { navController.navigate("orders") },
+                    vm = vm
                 )
                 Spacer(Modifier.height(12.dp))
             }

--- a/app/src/main/java/com/refit/app/ui/screen/MypageScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/MypageScreen.kt
@@ -7,19 +7,32 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.refit.app.data.cart.api.CartApi
+import com.refit.app.data.cart.modelAndView.CartBadgeViewModel
+import com.refit.app.data.cart.modelAndView.CartEditViewModel
+import com.refit.app.data.cart.repository.CartRepository
 import com.refit.app.network.UserPrefs
 import com.refit.app.ui.composable.mypage.MypageMenuSection
 import com.refit.app.ui.composable.mypage.MypageProfileCard
 import com.refit.app.ui.composable.mypage.RecentOrderSection
 import com.refit.app.data.me.modelAndView.OrderViewModel
+import com.refit.app.network.RetrofitInstance
 
 @Composable
-fun MypageScreen(navController: NavController, vm: OrderViewModel = viewModel()) {
+fun MypageScreen(
+    navController: NavController,
+    vm: OrderViewModel = viewModel(),
+) {
     val state by vm.state.collectAsState()
+    val api = RetrofitInstance.create(CartApi::class.java)
+    val repo = remember { CartRepository(api) }
+    val badgeVm = remember { CartBadgeViewModel(repo) }
+    val cartVm = remember { CartEditViewModel(repo, badgeVm) }
 
     LaunchedEffect(Unit) {
         vm.loadOrders()
@@ -50,7 +63,8 @@ fun MypageScreen(navController: NavController, vm: OrderViewModel = viewModel())
                 RecentOrderSection(
                     order = latestOrder,
                     onClickAll = { navController.navigate("orders") },
-                    vm = vm
+                    vm = vm,
+                    cartVm = cartVm
                 )
                 Spacer(Modifier.height(12.dp))
             }

--- a/app/src/main/java/com/refit/app/ui/screen/OrderListScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/OrderListScreen.kt
@@ -15,14 +15,26 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.refit.app.data.cart.api.CartApi
+import com.refit.app.data.cart.modelAndView.CartBadgeViewModel
+import com.refit.app.data.cart.modelAndView.CartEditViewModel
+import com.refit.app.data.cart.repository.CartRepository
 import com.refit.app.data.me.modelAndView.OrderViewModel
+import com.refit.app.network.RetrofitInstance
 import com.refit.app.ui.composable.mypage.OrderItemRow
 import com.refit.app.ui.theme.LightPurple
 import com.refit.app.ui.theme.Pretendard
 
 @Composable
-fun OrderListScreen(navController: NavController, vm: OrderViewModel = viewModel()) {
+fun OrderListScreen(
+    navController: NavController,
+    vm: OrderViewModel = viewModel(),
+) {
     val state by vm.state.collectAsState()
+    val api = RetrofitInstance.create(CartApi::class.java)
+    val repo = remember { CartRepository(api) }
+    val badgeVm = remember { CartBadgeViewModel(repo) }
+    val cartVm = remember { CartEditViewModel(repo, badgeVm) }
 
     LaunchedEffect(Unit) {
         vm.loadOrders()
@@ -73,7 +85,7 @@ fun OrderListScreen(navController: NavController, vm: OrderViewModel = viewModel
                             }
 
                             order.items.forEach { item ->
-                                OrderItemRow(item, vm)
+                                OrderItemRow(item, vm, cartVm)
                                 Spacer(Modifier.height(12.dp))
                             }
                         }

--- a/app/src/main/java/com/refit/app/ui/screen/OrderListScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/OrderListScreen.kt
@@ -73,7 +73,7 @@ fun OrderListScreen(navController: NavController, vm: OrderViewModel = viewModel
                             }
 
                             order.items.forEach { item ->
-                                OrderItemRow(item)
+                                OrderItemRow(item, vm)
                                 Spacer(Modifier.height(12.dp))
                             }
                         }

--- a/app/src/main/java/com/refit/app/util/file/FileUtils.kt
+++ b/app/src/main/java/com/refit/app/util/file/FileUtils.kt
@@ -1,0 +1,29 @@
+package com.refit.app.util.file
+
+import android.content.Context
+import android.net.Uri
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+
+object FileUtils {
+
+    fun getFileFromUri(context: Context, uri: Uri): File? {
+        return try {
+            val inputStream: InputStream? = context.contentResolver.openInputStream(uri)
+            val tempFile = File.createTempFile("upload_", ".tmp", context.cacheDir)
+            tempFile.deleteOnExit()
+
+            val outputStream = FileOutputStream(tempFile)
+            inputStream?.copyTo(outputStream)
+
+            inputStream?.close()
+            outputStream.close()
+
+            tempFile
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_camera.xml
+++ b/app/src/main/res/drawable/ic_camera.xml
@@ -1,0 +1,27 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+
+    <!-- 카메라 본체 (전체 흰색 채움 + 검은색 윤곽) -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:strokeColor="#000000"
+        android:strokeWidth="2"
+        android:pathData="M20 5h-3.2l-1.8-2H9L7.2 5H4c-1.1 0-2 .9-2 2v12c0
+                          1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2z" />
+
+    <!-- 렌즈 (흰색 내부 + 검은색 윤곽) -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:strokeColor="#000000"
+        android:strokeWidth="2"
+        android:pathData="M12 17c2.8 0 5-2.2 5-5s-2.2-5-5-5-5
+                          2.2-5 5 2.2 5 5 5z" />
+
+    <!-- 뷰파인더 작은 점 (검은색 채움) -->
+    <path
+        android:fillColor="#000000"
+        android:pathData="M17.5 8.5a1 1 0 1 0 0.001-2.001A1 1 0 0 0 17.5 8.5z" />
+</vector>


### PR DESCRIPTION
## #️⃣ Issue Number
#39 

## 📝 요약(Summary)
- 로그인시 삼성헬스 정보 원격DB 저장
- 사진변경 api 연동
- 교환/반품신청 api 연동 및 팝업안내 추가
- 장바구니 추가 연동
- 조합 좋아요 해제 api 연동

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
