### PR TITLE
[FEAT] 카카오/일반 로그인 시 프로필 사진 SharedPreferences에 저장 (#57)

### DIFF
--- a/app/src/main/java/com/refit/app/data/auth/model/LoginRequest.kt
+++ b/app/src/main/java/com/refit/app/data/auth/model/LoginRequest.kt
@@ -11,5 +11,6 @@ data class LoginResponse(
     val health: HealthInfoDto?,
     val hair: HairInfoDto?,
     val skin: SkinInfoDto?,
+    val profileImageUrl: String?,
     val refreshToken: String?
 )

--- a/app/src/main/java/com/refit/app/data/auth/modelAndView/AuthViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/auth/modelAndView/AuthViewModel.kt
@@ -71,6 +71,7 @@ class AuthViewModel : ViewModel() {
                     hair     = data?.hair,
                     skin     = data?.skin
                 )
+                UserPrefs.setProfileUrl(data?.profileImageUrl)
 
                 // access가 비어있어도(예외상황) refresh로 재발급 로직을 이후에 돌릴 수 있으니 성공 처리
                 loggedIn = true

--- a/app/src/main/java/com/refit/app/data/auth/modelAndView/KakaoLoginViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/auth/modelAndView/KakaoLoginViewModel.kt
@@ -101,6 +101,7 @@ class KakaoLoginViewModel : ViewModel() {
                         hair     = data.hair,
                         skin     = data.skin
                     )
+                    UserPrefs.setProfileUrl(data.profileImageUrl)
                     onLoggedIn()
                 }
             } catch (t: Throwable) {
@@ -145,6 +146,7 @@ class KakaoLoginViewModel : ViewModel() {
                     hair     = data.hair,
                     skin     = data.skin
                 )
+                UserPrefs.setProfileUrl(data.profileImageUrl)
                 onSuccessLogin()
             } catch (t: Throwable) {
                 onError(t.message ?: "카카오 회원가입 중 오류")


### PR DESCRIPTION
## #️⃣ Issue Number
#57 

## 📝 요약(Summary)
- 카카오 / 일반 로그인 후 SharePreferences에 프로필 url 저장

