### PR TITLE
[REFACTOR] 수정안 반영

### DIFF
--- a/app/src/main/java/com/refit/app/data/combination/modelAndView/LikedCombinationViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/combination/modelAndView/LikedCombinationViewModel.kt
@@ -76,4 +76,15 @@ class LikedCombinationViewModel(
             )
         }
     }
+
+    /** 찜한 조합 비우기 */
+    fun clearLikedCombinations() {
+        _state.value = _state.value.copy(
+            combinations = emptyList(),
+            isLoading = false,
+            error = null,
+            message = null,
+            isProcessing = false
+        )
+    }
 }

--- a/app/src/main/java/com/refit/app/data/health/reader/SleepReader.kt
+++ b/app/src/main/java/com/refit/app/data/health/reader/SleepReader.kt
@@ -38,11 +38,16 @@ suspend fun readSleep(
             Log.w("HealthRepo", "수면: 빈 페이지 (page=$pageCount) → 중단")
             break
         }
+
         page.records.forEach {
-            val d = it.startTime.atZone(zone).toLocalDate()
+            val end = it.endTime.atZone(zone)
             val minutes = Duration.between(it.startTime, it.endTime).toMinutes()
+
+            val d = end.toLocalDate()
+
             dailySleep[d] = (dailySleep[d] ?: 0L) + minutes
         }
+
         val next = page.pageToken ?: break
         if (pageCount > 50) {
             Log.e("HealthRepo", "수면: 페이지 50 초과 → 강제 중단")

--- a/app/src/main/java/com/refit/app/data/home/modelAndView/HomeViewModel.kt
+++ b/app/src/main/java/com/refit/app/data/home/modelAndView/HomeViewModel.kt
@@ -50,10 +50,9 @@ class HomeViewModel : ViewModel() {
                 val rows = HealthRepo.readDailyAll(ctx, days = 2)
                 if (rows.size >= 2) {
                     val today = rows.last()
-                    val yesterday = rows[rows.size - 2]
                     _uiState.value = _uiState.value.copy(
-                        steps = today.steps,                  // 걸음수는 오늘
-                        sleepMinutes = yesterday.sleepMinutes // 수면시간은 어제
+                        steps = today.steps,
+                        sleepMinutes = today.sleepMinutes
                     )
                 }
             } else {
@@ -120,12 +119,15 @@ class HomeViewModel : ViewModel() {
 
     // === 수면시간 포맷 ===
     fun formatSleep(minutes: Long): String {
-        return if (minutes <= 0) {
-            "-- 시간"
-        } else {
-            val h = minutes / 60
-            val m = minutes % 60
-            "${h}시간 ${m}분"
+        if (minutes <= 0) return "-- 시간"
+
+        val h = minutes / 60
+        val m = minutes % 60
+
+        return when {
+            h > 0 && m > 0 -> "${h}시간 ${m}분"
+            m == 0L && h > 0 -> "${h}시간"
+            else -> "${m}분"
         }
     }
 

--- a/app/src/main/java/com/refit/app/ui/composable/combiking/CombiKingSection.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/combiking/CombiKingSection.kt
@@ -203,7 +203,13 @@ fun CombiKingSection(
 
             // 등록 버튼
             FloatingActionButton(
-                onClick = { navController.navigate("combinationRegister") },
+                onClick = {
+                    val defaultType = when (category) {
+                        CommunityCategory.ALL, CommunityCategory.BEAUTY -> "beauty"
+                        CommunityCategory.HEALTH -> "health"
+                    }
+                    navController.navigate("combinationRegister/$defaultType")
+                },
                 shape = CircleShape,
                 containerColor = MainPurple,
                 contentColor = Color.White,

--- a/app/src/main/java/com/refit/app/ui/composable/combiking/CombiKingSection.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/combiking/CombiKingSection.kt
@@ -57,8 +57,8 @@ fun CombiKingSection(
 
     // 정렬 옵션
     val sortOptions = listOf(
-        "인기순" to "popular",
         "최신순" to "latest",
+        "인기순" to "popular",
         "가격낮은순" to "lowPrice",
         "가격높은순" to "highPrice"
     )

--- a/app/src/main/java/com/refit/app/ui/composable/combiking/CombiantionCard.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/combiking/CombiantionCard.kt
@@ -86,38 +86,47 @@ fun CombinationCard(
                 Spacer(Modifier.height(8.dp))
 
                 // 상품 이미지
-                Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
-                    val images = combination.productImages
-                    val size = 75.dp
-                    val shape = RoundedCornerShape(6.dp)
+                BoxWithConstraints(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    val spacing = 6.dp
+                    val itemSize = (maxWidth - spacing * 3) / 4
 
-                    images.take(4).forEachIndexed { index, url ->
-                        Box(
-                            modifier = Modifier
-                                .size(size)
-                                .clip(shape)
-                                .background(Color.White, shape),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            AsyncImage(
-                                model = url,
-                                contentDescription = null,
-                                contentScale = ContentScale.Crop,
-                                modifier = Modifier.matchParentSize().clip(shape)
-                            )
-                            if (index == 3 && images.size > 4) {
-                                Box(
-                                    Modifier
-                                        .matchParentSize()
-                                        .background(Color.Black.copy(alpha = 0.45f), shape)
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(spacing)
+                    ) {
+                        val images = combination.productImages
+                        val shape = RoundedCornerShape(6.dp)
+
+                        images.take(4).forEachIndexed { index, url ->
+                            Box(
+                                modifier = Modifier
+                                    .size(itemSize)
+                                    .clip(shape)
+                                    .background(Color.White, shape),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                AsyncImage(
+                                    model = url,
+                                    contentDescription = null,
+                                    contentScale = ContentScale.Crop,
+                                    modifier = Modifier.matchParentSize().clip(shape)
                                 )
-                                Text(
-                                    text = "+${images.size - 3}",
-                                    color = Color.White,
-                                    fontSize = 20.sp,
-                                    fontWeight = FontWeight.Bold,
-                                    fontFamily = Pretendard
-                                )
+                                if (index == 3 && images.size > 4) {
+                                    Box(
+                                        Modifier
+                                            .matchParentSize()
+                                            .background(Color.Black.copy(alpha = 0.45f), shape)
+                                    )
+                                    Text(
+                                        text = "+${images.size - 3}",
+                                        color = Color.White,
+                                        fontSize = 20.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        fontFamily = Pretendard
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/refit/app/ui/composable/combiking/CombinationTypeChangeDialog.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/combiking/CombinationTypeChangeDialog.kt
@@ -1,10 +1,13 @@
 package com.refit.app.ui.composable.combiking
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -25,14 +28,19 @@ fun CombinationTypeChangeDialog(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color(0x66000000)),
+            .background(Color(0x66000000))
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ) { onDismiss() },
         contentAlignment = Alignment.Center
     ) {
         Column(
             modifier = Modifier
                 .width(280.dp)
                 .background(Color.White, shape = RoundedCornerShape(16.dp))
-                .padding(24.dp),
+                .padding(24.dp)
+                .clickable(enabled = false) {},
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             // 상단 느낌표 아이콘

--- a/app/src/main/java/com/refit/app/ui/composable/common/MainScreenWithBottomNav.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/common/MainScreenWithBottomNav.kt
@@ -444,21 +444,23 @@ fun MainScreenWithBottomNav(
                 }
 
                 // 조합 등록 페이지
-                composable("combinationRegister") { backStackEntry ->
+                composable(
+                    route = "combinationRegister/{defaultType}",
+                    arguments = listOf(navArgument("defaultType") { defaultValue = "beauty" })
+                ) { backStackEntry ->
                     val selectedProducts =
                         backStackEntry.savedStateHandle
                             .getStateFlow("selectedProducts", emptyList<Product>())
                             .collectAsState().value
 
+                    val defaultType = backStackEntry.arguments?.getString("defaultType") ?: "beauty"
+
                     CombinationRegisterScreen(
                         navController = navController,
                         selectedProducts = selectedProducts,
-                        onSearchClick = { bh ->
-                            navController.navigate("productSelect/$bh")
-                        },
-                        onRegisterSuccess = {
-                            navController.popBackStack()
-                        }
+                        defaultType = defaultType,
+                        onSearchClick = { bh -> navController.navigate("productSelect/$bh") },
+                        onRegisterSuccess = { navController.popBackStack() }
                     )
                 }
 

--- a/app/src/main/java/com/refit/app/ui/composable/health/RoundedBarChartRenderer.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/health/RoundedBarChartRenderer.kt
@@ -1,0 +1,127 @@
+package com.refit.app.ui.composable.health
+
+import android.graphics.Canvas
+import android.graphics.RectF
+import com.github.mikephil.charting.animation.ChartAnimator
+import com.github.mikephil.charting.data.BarEntry
+import com.github.mikephil.charting.interfaces.dataprovider.BarDataProvider
+import com.github.mikephil.charting.interfaces.datasets.IBarDataSet
+import com.github.mikephil.charting.renderer.BarChartRenderer
+import com.github.mikephil.charting.utils.Utils
+import com.github.mikephil.charting.utils.ViewPortHandler
+
+class RoundedBarChartRenderer(
+    chart: BarDataProvider,
+    animator: ChartAnimator,
+    viewPortHandler: ViewPortHandler
+) : BarChartRenderer(chart, animator, viewPortHandler) {
+
+    private val mBarShadowRectBuffer = RectF()
+
+    override fun drawDataSet(c: Canvas, dataSet: IBarDataSet, index: Int) {
+        val trans = mChart.getTransformer(dataSet.axisDependency)
+
+        mBarBorderPaint.color = dataSet.barBorderColor
+        mBarBorderPaint.strokeWidth = Utils.convertDpToPixel(dataSet.barBorderWidth)
+
+        val drawBorder = dataSet.barBorderWidth > 0f
+
+        val phaseX = mAnimator.phaseX
+        val phaseY = mAnimator.phaseY
+
+        if (mChart.isDrawBarShadowEnabled) {
+            mShadowPaint.color = dataSet.barShadowColor
+
+            val barData = mChart.barData
+
+            val barWidthHalf = barData.barWidth / 2.0f
+            var x: Int = 0
+            while (x < Math.min(
+                    Math.ceil((dataSet.entryCount.toFloat() * phaseX).toDouble()).toInt(),
+                    dataSet.entryCount
+                )
+            ) {
+                val e = dataSet.getEntryForIndex(x) as BarEntry
+
+                val xPos = e.x
+
+                mBarShadowRectBuffer.left = xPos - barWidthHalf
+                mBarShadowRectBuffer.right = xPos + barWidthHalf
+
+                trans.rectValueToPixel(mBarShadowRectBuffer)
+
+                if (!mViewPortHandler.isInBoundsLeft(mBarShadowRectBuffer.right)) {
+                    x++
+                    continue
+                }
+
+                if (!mViewPortHandler.isInBoundsRight(mBarShadowRectBuffer.left)) break
+
+                mBarShadowRectBuffer.top = mViewPortHandler.contentTop()
+                mBarShadowRectBuffer.bottom = mViewPortHandler.contentBottom()
+
+                c.drawRoundRect(
+                    mBarShadowRectBuffer, 20f, 20f, mShadowPaint
+                )
+                x++
+            }
+        }
+
+        mBarBuffers[index].apply {
+            setPhases(phaseX, phaseY)
+            setDataSet(index)
+            setInverted(mChart.isInverted(dataSet.axisDependency))
+            setBarWidth(mChart.barData.barWidth)
+
+            feed(dataSet)
+
+            trans.pointValuesToPixel(buffer)
+
+            for (j in 0 until buffer.size step 4) {
+                if (!mViewPortHandler.isInBoundsLeft(buffer[j + 2])) continue
+                if (!mViewPortHandler.isInBoundsRight(buffer[j])) break
+
+                val left = buffer[j]
+                val top = buffer[j + 1]
+                val right = buffer[j + 2]
+                val bottom = buffer[j + 3]
+
+                val paint = mRenderPaint
+                paint.color = dataSet.getColor(j / 4)
+
+                // 둥근 모서리 적용
+                c.drawRoundRect(RectF(left, top, right, bottom), 30f, 30f, paint)
+
+                if (drawBorder) {
+                    c.drawRoundRect(RectF(left, top, right, bottom), 30f, 30f, mBarBorderPaint)
+                }
+            }
+        }
+    }
+
+    override fun drawHighlighted(c: Canvas, indices: Array<com.github.mikephil.charting.highlight.Highlight>) {
+        val barData = mChart.barData
+
+        for (high in indices) {
+            val set = barData.getDataSetByIndex(high.dataSetIndex) ?: continue
+            if (!set.isHighlightEnabled) continue
+
+            val e = set.getEntryForXValue(high.x, high.y) ?: continue
+            if (!isInBoundsX(e, set)) continue
+
+            val trans = mChart.getTransformer(set.axisDependency)
+            mBarRect.set(
+                e.x - barData.barWidth / 2f,
+                0f,
+                e.x + barData.barWidth / 2f,
+                e.y
+            )
+            trans.rectToPixelPhase(mBarRect, mAnimator.phaseY)
+
+            mHighlightPaint.color = android.graphics.Color.argb(70, 0, 0, 0)
+
+            c.drawRoundRect(mBarRect, 30f, 30f, mHighlightPaint)
+        }
+    }
+
+}

--- a/app/src/main/java/com/refit/app/ui/composable/home/HashtagChip.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/home/HashtagChip.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.padding
 import androidx.compose.ui.text.font.FontWeight
+import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
 
 @Composable
@@ -17,14 +18,14 @@ fun HashtagChip(text: String) {
     Surface(
         shape = RoundedCornerShape(8.dp),
         color = Color.White,
-        border = androidx.compose.foundation.BorderStroke(1.dp, Color(0xFF7A3EFF))
+        border = androidx.compose.foundation.BorderStroke(1.5.dp, MainPurple)
     ) {
         Text(
             text = text,
-            color = Color(0xFF7A3EFF),
+            color = MainPurple,
             fontSize = 12.sp,
             fontFamily = Pretendard,
-            fontWeight = FontWeight.Medium,
+            fontWeight = FontWeight.SemiBold,
             modifier = Modifier.padding(horizontal = 10.dp)
         )
     }

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/CancelOrderReasonDialog.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/CancelOrderReasonDialog.kt
@@ -143,6 +143,9 @@ fun CancelOrderReasonDialog(
                         MyOrderActionButton(
                             text = if (step == 1) "다음 단계" else "환불 신청",
                             modifier = Modifier.weight(1f).height(42.dp),
+                            textColor = Color.White,
+                            backgroundColor = MainPurple,
+                            borderColor = MainPurple,
                             onClick = {
                                 if (step == 1) {
                                     if (selectedReason != null) step = 2

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/ExchangeReturnReasonDialog.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/ExchangeReturnReasonDialog.kt
@@ -1,6 +1,5 @@
 package com.refit.app.ui.composable.mypage
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -18,7 +17,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
-import com.refit.app.ui.theme.LightPurple
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
 
@@ -171,58 +169,35 @@ fun ExchangeReturnReasonDialog(
                         horizontalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         // 취소 버튼
-                        Box(
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(42.dp)
-                                .background(Color.White, shape = RoundedCornerShape(8.dp))
-                                .border(
-                                    width = 1.dp,
-                                    color = Color(0xFFCCCCCC),
-                                    shape = RoundedCornerShape(8.dp)
-                                )
-                                .clickable { onDismiss() },
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = "취소",
-                                fontFamily = Pretendard,
-                                fontSize = 14.sp,
-                                fontWeight = FontWeight.Medium,
-                                color = Color(0xFF666666)
-                            )
-                        }
+                        MyOrderActionButton(
+                            text = "취소",
+                            modifier = Modifier.weight(1f).height(42.dp),
+                            onClick = onDismiss
+                        )
 
                         // 다음 단계 / 신청 완료 버튼
-                        Box(
-                            modifier = Modifier
-                                .weight(1f)
-                                .height(42.dp)
-                                .background(
-                                    if (if (step == 1) selectedReason != null else selectedAction != null)
-                                        MainPurple else Color(0xFFE0E0E0),
-                                    shape = RoundedCornerShape(8.dp)
-                                )
-                                .clickable(
-                                    enabled = if (step == 1) selectedReason != null else selectedAction != null
-                                ) {
-                                    if (step == 1) step = 2
-                                    else {
-                                        if (selectedAction == "exchange") onConfirmExchange(orderItemId)
-                                        if (selectedAction == "return") onConfirmReturn(orderItemId)
+                        MyOrderActionButton(
+                            text = if (step == 1) "다음 단계" else "신청 완료",
+                            modifier = Modifier.weight(1f).height(42.dp),
+                            textColor = Color.White,
+                            backgroundColor = MainPurple,
+                            borderColor = MainPurple,
+                            onClick = {
+                                if (step == 1) {
+                                    if (selectedReason != null) {
+                                        step = 2
+                                    }
+                                } else {
+                                    if (selectedAction != null) {
+                                        when (selectedAction) {
+                                            "exchange" -> onConfirmExchange(orderItemId)
+                                            "return" -> onConfirmReturn(orderItemId)
+                                        }
                                         onDismiss()
                                     }
-                                },
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Text(
-                                text = if (step == 1) "다음 단계" else "신청 완료",
-                                fontFamily = Pretendard,
-                                fontSize = 15.sp,
-                                fontWeight = FontWeight.Medium,
-                                color = Color.White
-                            )
-                        }
+                                }
+                            }
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/MyOrderActionButton.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/MyOrderActionButton.kt
@@ -20,15 +20,18 @@ import com.refit.app.ui.theme.Pretendard
 fun MyOrderActionButton(
     text: String,
     modifier: Modifier = Modifier,
+    textColor: Color = Color(0xFF999999),
+    backgroundColor: Color = Color.White,
+    borderColor: Color = Color(0xFFCCCCCC),
     onClick: () -> Unit = {}
 ) {
     Box(
         modifier = modifier
             .height(30.dp)
-            .background(Color.White, shape = RoundedCornerShape(8.dp))
+            .background(backgroundColor, shape = RoundedCornerShape(8.dp))
             .border(
                 width = 1.dp,
-                color = Color(0xFFCCCCCC),
+                color = borderColor,
                 shape = RoundedCornerShape(8.dp)
             )
             .clickable { onClick() },
@@ -39,7 +42,7 @@ fun MyOrderActionButton(
             fontFamily = Pretendard,
             fontSize = 12.sp,
             fontWeight = FontWeight.Medium,
-            color = Color(0xFF999999)
+            color = textColor
         )
     }
 }

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/MypageProfileCard.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/MypageProfileCard.kt
@@ -3,7 +3,6 @@ package com.refit.app.ui.composable.mypage
 import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -41,7 +40,6 @@ import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 
-
 @Composable
 fun MypageProfileCard(
     nickname: String,
@@ -56,7 +54,6 @@ fun MypageProfileCard(
     val savedUrl = UserPrefs.getProfileUrl()
     val finalUrl = profileUrl ?: savedUrl
 
-    // 갤러리/카메라 런처 준비
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.GetContent()
     ) { uri ->
@@ -67,11 +64,11 @@ fun MypageProfileCard(
                 val body = MultipartBody.Part.createFormData("profileImage", f.name, requestFile)
                 vm.updateProfileImage(body)
             } ?: run {
-                // 파일 변환 실패 처리
                 Log.e("Profile", "Failed to convert URI to File")
             }
         }
     }
+
     Surface(
         modifier = Modifier
             .fillMaxWidth()
@@ -85,40 +82,33 @@ fun MypageProfileCard(
             modifier = Modifier.padding(20.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // 프로필 이미지 박스
+            // 프로필 이미지
             Box(
                 modifier = Modifier
                     .size(80.dp)
                     .clickable { launcher.launch("image/*") },
                 contentAlignment = Alignment.BottomEnd
             ) {
-                // 프사 부분
-                Box(
+                AsyncImage(
+                    model = finalUrl,
+                    contentDescription = null,
                     modifier = Modifier
-                        .size(80.dp)
-                        .clickable { launcher.launch("image/*") },
-                    contentAlignment = Alignment.BottomEnd
-                ) {
-                    AsyncImage(
-                        model = finalUrl,
-                        contentDescription = null,
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .clip(CircleShape)
-                            .border(2.dp, MainPurple, CircleShape)
-                            .background(Color.White),
-                        contentScale = ContentScale.Crop
-                    )
-                    Icon(
-                        painter = painterResource(R.drawable.ic_camera),
-                        contentDescription = "프로필 변경",
-                        tint = Color.Unspecified,
-                        modifier = Modifier
-                            .size(36.dp)
-                            .offset(x = 8.dp, y = 8.dp)
-                    )
-                }
+                        .fillMaxSize()
+                        .clip(CircleShape)
+                        .border(2.dp, MainPurple, CircleShape)
+                        .background(Color.White),
+                    contentScale = ContentScale.Crop
+                )
+                Icon(
+                    painter = painterResource(R.drawable.ic_camera),
+                    contentDescription = "프로필 변경",
+                    tint = Color.Unspecified,
+                    modifier = Modifier
+                        .size(36.dp)
+                        .offset(x = 8.dp, y = 8.dp)
+                )
             }
+
             Spacer(Modifier.width(12.dp))
 
             // 오른쪽 정보
@@ -127,14 +117,32 @@ fun MypageProfileCard(
                 horizontalAlignment = Alignment.Start,
                 verticalArrangement = Arrangement.Center
             ) {
-                Text(
-                    text = nickname,
-                    fontFamily = Pretendard,
-                    fontWeight = FontWeight.SemiBold,
-                    fontSize = 18.sp,
-                    color = Color.Black
-                )
+                // 닉네임 + 기본 정보 수정 버튼
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = nickname,
+                        fontFamily = Pretendard,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 18.sp,
+                        color = Color.Black
+                    )
+                    IconButton(
+                        onClick = onArrowClick,
+                        modifier = Modifier.size(24.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                            contentDescription = "이동",
+                            tint = Color.Gray
+                        )
+                    }
+                }
+
                 Spacer(Modifier.height(8.dp))
+
+                // 해시태그
                 Row(
                     modifier = Modifier.horizontalScroll(rememberScrollState()),
                     verticalAlignment = Alignment.CenterVertically
@@ -144,7 +152,10 @@ fun MypageProfileCard(
                         if (idx != tags.lastIndex) Spacer(Modifier.width(8.dp))
                     }
                 }
+
                 Spacer(Modifier.height(12.dp))
+
+                // 내 타입 수정 버튼
                 Box(
                     modifier = Modifier
                         .height(28.dp)
@@ -163,14 +174,7 @@ fun MypageProfileCard(
                     )
                 }
             }
-
-            IconButton(onClick = onArrowClick) {
-                Icon(
-                    imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
-                    contentDescription = "이동",
-                    tint = Color.Gray
-                )
-            }
         }
     }
 }
+

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/OrderItemRow.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/OrderItemRow.kt
@@ -9,7 +9,9 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import com.refit.app.R
 import androidx.compose.material3.Icon
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
@@ -33,6 +35,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.navigation.NavController
 import com.refit.app.data.cart.modelAndView.CartEditViewModel
+import com.refit.app.util.common.PriceUtil
 import com.refit.app.util.order.OrderStatusMapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -92,29 +95,32 @@ fun OrderItemRow(
                 )
 
                 // 가격/수량
-                Row(verticalAlignment = Alignment.CenterVertically) {
+                Row {
+                    Text(
+                        text = PriceUtil.formatPrice(item.price.toLong()),
+                        fontFamily = Pretendard,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Bold,
+                        modifier = Modifier.alignByBaseline()
+                    )
                     if (item.originalPrice > item.price) {
+                        Spacer(Modifier.width(4.dp))
                         Text(
-                            text = "${item.originalPrice}원",
+                            text = PriceUtil.formatPrice(item.originalPrice.toLong()),
                             fontFamily = Pretendard,
                             fontSize = 12.sp,
                             color = Color.Gray,
                             textDecoration = TextDecoration.LineThrough,
-                            modifier = Modifier.padding(end = 4.dp)
+                            modifier = Modifier.alignByBaseline()
                         )
                     }
+                    Spacer(Modifier.width(6.dp))
                     Text(
-                        text = "${item.price}원",
-                        fontFamily = Pretendard,
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.Bold
-                    )
-                    Text(
-                        text = " | ${item.quantity}개",
+                        text = "| ${item.quantity}개",
                         fontFamily = Pretendard,
                         fontSize = 13.sp,
                         color = Color.Gray,
-                        modifier = Modifier.padding(start = 6.dp)
+                        modifier = Modifier.alignByBaseline()
                     )
                 }
 
@@ -174,9 +180,17 @@ fun OrderItemRow(
                     .clickable {
                         cartVm.addOne(item.productId, 1)
                         scope.launch {
-                            snackbarHostState.showSnackbar(
-                                message = "${item.productName}이 장바구니에 추가되었습니다."
+                            snackbarHostState.currentSnackbarData?.dismiss()
+
+                            val result = snackbarHostState.showSnackbar(
+                                message = "${item.productName}을 장바구니에 담았어요.",
+                                actionLabel = "바로가기",
+                                withDismissAction = true,
+                                duration = SnackbarDuration.Short
                             )
+                            if (result == SnackbarResult.ActionPerformed) {
+                                navController.navigate("cart")
+                            }
                         }
                     },
                 contentAlignment = Alignment.Center

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
@@ -1,8 +1,5 @@
 package com.refit.app.ui.composable.mypage
 
-import android.view.LayoutInflater
-import android.widget.TextView
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -44,7 +41,7 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun RecentOrderSection(
-    order: OrderResponse,
+    order: OrderResponse?,
     onClickAll: () -> Unit,
     vm: OrderViewModel,
     cartVm: CartEditViewModel,
@@ -112,193 +109,217 @@ fun RecentOrderSection(
             modifier = Modifier.fillMaxWidth()
         ) {
             Column(Modifier.padding(16.dp)) {
-                val firstItem = order.items.firstOrNull()
-                if (firstItem != null) {
-                    Column {
-                        Text(
-                            text = firstItem.createdAt.take(10).replace("-", "."),
-                            fontSize = 18.sp,
-                            fontWeight = FontWeight.Bold,
-                            fontFamily = Pretendard,
-                            color = MainPurple
-                        )
-                        Spacer(Modifier.height(4.dp))
-                        Text(
-                            text = "주문번호 ${firstItem.orderCode}",
-                            fontSize = 12.sp,
-                            fontFamily = Pretendard,
-                            color = Color.Gray
-                        )
-                    }
-                }
-
-                Spacer(Modifier.height(8.dp))
-                HorizontalDivider(thickness = 1.dp, color = Color.LightGray)
-
-                order.items.forEach { item ->
-                    Row(
+                if (order == null) {
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(vertical = 8.dp)
-                            .clickable {
-                                navController.navigate("product/${item.productId}")
-                            },
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically
+                            .padding(vertical = 24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.Center
                     ) {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            AsyncImage(
-                                model = item.thumbnailUrl,
-                                contentDescription = item.productName,
-                                modifier = Modifier.size(60.dp)
+                        Icon(
+                            painter = painterResource(id = R.drawable.jellbbo_default),
+                            contentDescription = "주문 내역 없음",
+                            tint = Color.Unspecified,
+                            modifier = Modifier.size(100.dp)
+                        )
+                        Text(
+                            text = "아직 주문 내역이 없어요.",
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.SemiBold,
+                            color = Color.Gray,
+                            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+                        )
+                    }
+                } else {
+                    val firstItem = order.items.firstOrNull()
+                    if (firstItem != null) {
+                        Column {
+                            Text(
+                                text = firstItem.createdAt.take(10).replace("-", "."),
+                                fontSize = 18.sp,
+                                fontWeight = FontWeight.Bold,
+                                fontFamily = Pretendard,
+                                color = MainPurple
                             )
-                            Spacer(Modifier.width(12.dp))
-                            Column {
-                                Text(
-                                    text = OrderStatusMapper.getStatusText(item.status),
-                                    color = MainPurple,
-                                    fontSize = 12.sp,
-                                    fontFamily = Pretendard,
-                                    fontWeight = FontWeight.Bold
+                            Spacer(Modifier.height(4.dp))
+                            Text(
+                                text = "주문번호 ${firstItem.orderCode}",
+                                fontSize = 12.sp,
+                                fontFamily = Pretendard,
+                                color = Color.Gray
+                            )
+                        }
+                    }
+
+                    Spacer(Modifier.height(8.dp))
+                    HorizontalDivider(thickness = 1.dp, color = Color.LightGray)
+
+                    order.items.forEach { item ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 8.dp)
+                                .clickable {
+                                    navController.navigate("product/${item.productId}")
+                                },
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                AsyncImage(
+                                    model = item.thumbnailUrl,
+                                    contentDescription = item.productName,
+                                    modifier = Modifier.size(60.dp)
                                 )
-                                Text(
-                                    text = "[${item.brand}] ${item.productName}".limitWithEllipsis(10),
-                                    fontSize = 14.sp,
-                                    fontFamily = Pretendard,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis
-                                )
-                                Row {
+                                Spacer(Modifier.width(12.dp))
+                                Column {
                                     Text(
-                                        text = PriceUtil.formatPrice(item.price.toLong()),
-                                        fontSize = 13.sp,
-                                        fontWeight = FontWeight.Bold,
+                                        text = OrderStatusMapper.getStatusText(item.status),
+                                        color = MainPurple,
+                                        fontSize = 12.sp,
                                         fontFamily = Pretendard,
-                                        modifier = Modifier.alignByBaseline()
+                                        fontWeight = FontWeight.Bold
                                     )
-                                    if (item.originalPrice > item.price) {
+                                    Text(
+                                        text = "[${item.brand}] ${item.productName}".limitWithEllipsis(10),
+                                        fontSize = 14.sp,
+                                        fontFamily = Pretendard,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                    Row {
+                                        Text(
+                                            text = PriceUtil.formatPrice(item.price.toLong()),
+                                            fontSize = 13.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            fontFamily = Pretendard,
+                                            modifier = Modifier.alignByBaseline()
+                                        )
+                                        if (item.originalPrice > item.price) {
+                                            Spacer(Modifier.width(6.dp))
+                                            Text(
+                                                text = PriceUtil.formatPrice(item.originalPrice.toLong()),
+                                                fontSize = 12.sp,
+                                                fontFamily = Pretendard,
+                                                color = Color.Gray,
+                                                textDecoration = TextDecoration.LineThrough,
+                                                modifier = Modifier.alignByBaseline()
+                                            )
+                                        }
                                         Spacer(Modifier.width(6.dp))
                                         Text(
-                                            text = PriceUtil.formatPrice(item.originalPrice.toLong()),
+                                            text = "| ${item.quantity}개",
                                             fontSize = 12.sp,
                                             fontFamily = Pretendard,
                                             color = Color.Gray,
-                                            textDecoration = TextDecoration.LineThrough,
                                             modifier = Modifier.alignByBaseline()
                                         )
                                     }
-                                    Spacer(Modifier.width(6.dp))
-                                    Text(
-                                        text = "| ${item.quantity}개",
-                                        fontSize = 12.sp,
-                                        fontFamily = Pretendard,
-                                        color = Color.Gray,
-                                        modifier = Modifier.alignByBaseline()
-                                    )
-                                }
 
-                                // 결제완료 → 주문취소 버튼
-                                if (item.status == 1) {
-                                    var showCancelDialog by remember { mutableStateOf(false) }
+                                    // 결제완료 → 주문취소 버튼
+                                    if (item.status == 1) {
+                                        var showCancelDialog by remember { mutableStateOf(false) }
 
-                                    if (showCancelDialog) {
-                                        // 남은 취소 가능 수량 계산
-                                        // item.canceledCount 가 없다면 아래 remainQty는 item.quantity 로 둠
-                                        val remainQty = run {
-                                            val canceled = try {
-                                                @Suppress("UNUSED_VARIABLE")
-                                                (item::class.java.getDeclaredField("canceledCount")
-                                                    .apply { isAccessible = true }
-                                                    .get(item) as? Int) ?: 0
-                                            } catch (_: Exception) {
-                                                0
+                                        if (showCancelDialog) {
+                                            // 남은 취소 가능 수량 계산
+                                            // item.canceledCount 가 없다면 아래 remainQty는 item.quantity 로 둠
+                                            val remainQty = run {
+                                                val canceled = try {
+                                                    @Suppress("UNUSED_VARIABLE")
+                                                    (item::class.java.getDeclaredField("canceledCount")
+                                                        .apply { isAccessible = true }
+                                                        .get(item) as? Int) ?: 0
+                                                } catch (_: Exception) {
+                                                    0
+                                                }
+                                                val q = item.quantity - canceled
+                                                if (q < 1) 1 else q
                                             }
-                                            val q = item.quantity - canceled
-                                            if (q < 1) 1 else q
+
+                                            CancelOrderReasonDialog(
+                                                orderItemId = item.orderItemId,
+                                                unitPrice = item.price,
+                                                maxQty = remainQty,
+                                                onDismiss = { showCancelDialog = false },
+                                                onConfirmCancel = { id, reason, count ->
+                                                    //  cancelAmount = unitPrice * count 으로 요청
+                                                    vm.requestCancel(
+                                                        orderItemId = id,
+                                                        unitPrice = item.price,
+                                                        count = count,
+                                                        reason = reason
+                                                    )
+                                                }
+                                            )
                                         }
 
-                                        CancelOrderReasonDialog(
-                                            orderItemId = item.orderItemId,
-                                            unitPrice = item.price,
-                                            maxQty = remainQty,
-                                            onDismiss = { showCancelDialog = false },
-                                            onConfirmCancel = { id, reason, count ->
-                                                //  cancelAmount = unitPrice * count 으로 요청
-                                                vm.requestCancel(
-                                                    orderItemId = id,
-                                                    unitPrice = item.price,
-                                                    count = count,
-                                                    reason = reason
-                                                )
-                                            }
+                                        MyOrderActionButton(
+                                            text = "주문 취소",
+                                            modifier = Modifier
+                                                .width(90.dp)
+                                                .height(30.dp)
+                                                .padding(top = 6.dp),
+                                            onClick = { showCancelDialog = true }
                                         )
                                     }
 
-                                    MyOrderActionButton(
-                                        text = "주문 취소",
-                                        modifier = Modifier
-                                            .width(90.dp)
-                                            .height(30.dp)
-                                            .padding(top = 6.dp),
-                                        onClick = { showCancelDialog = true }
-                                    )
-                                }
+                                    // 배송완료 → 교환/반품 신청 버튼
+                                    if (item.status == 6) {
+                                        var showDialog by remember { mutableStateOf(false) }
 
-                                // 배송완료 → 교환/반품 신청 버튼
-                                if (item.status == 6) {
-                                    var showDialog by remember { mutableStateOf(false) }
+                                        if (showDialog) {
+                                            ExchangeReturnReasonDialog(
+                                                orderItemId = item.orderItemId,
+                                                onDismiss = { showDialog = false },
+                                                onConfirmExchange = { vm.requestExchange(it) },
+                                                onConfirmReturn = { vm.requestReturn(it) }
+                                            )
+                                        }
 
-                                    if (showDialog) {
-                                        ExchangeReturnReasonDialog(
-                                            orderItemId = item.orderItemId,
-                                            onDismiss = { showDialog = false },
-                                            onConfirmExchange = { vm.requestExchange(it) },
-                                            onConfirmReturn = { vm.requestReturn(it) }
+                                        MyOrderActionButton(
+                                            text = "교환/반품",
+                                            modifier = Modifier
+                                                .width(90.dp)
+                                                .height(28.dp)
+                                                .padding(top = 6.dp),
+                                            onClick = { showDialog = true }
                                         )
                                     }
-
-                                    MyOrderActionButton(
-                                        text = "교환/반품",
-                                        modifier = Modifier
-                                            .width(90.dp)
-                                            .height(28.dp)
-                                            .padding(top = 6.dp),
-                                        onClick = { showDialog = true }
-                                    )
                                 }
                             }
-                        }
 
-                        Box(
-                            modifier = Modifier
-                                .align(Alignment.CenterVertically)
-                                .size(40.dp)
-                                .clip(RoundedCornerShape(8.dp))
-                                .border(1.dp, Color.Black, RoundedCornerShape(8.dp))
-                                .clickable {
-                                    cartVm.addOne(item.productId, 1)
-                                    scope.launch {
-                                        snackbarHostState.currentSnackbarData?.dismiss()
+                            Box(
+                                modifier = Modifier
+                                    .align(Alignment.CenterVertically)
+                                    .size(40.dp)
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .border(1.dp, Color.Black, RoundedCornerShape(8.dp))
+                                    .clickable {
+                                        cartVm.addOne(item.productId, 1)
+                                        scope.launch {
+                                            snackbarHostState.currentSnackbarData?.dismiss()
 
-                                        val result = snackbarHostState.showSnackbar(
-                                            message = "${item.productName}을 장바구니에 담았어요.",
-                                            actionLabel = "바로가기",
-                                            withDismissAction = true,
-                                            duration = SnackbarDuration.Short
-                                        )
-                                        if (result == SnackbarResult.ActionPerformed) {
-                                            navController.navigate("cart")
+                                            val result = snackbarHostState.showSnackbar(
+                                                message = "${item.productName}을 장바구니에 담았어요.",
+                                                actionLabel = "바로가기",
+                                                withDismissAction = true,
+                                                duration = SnackbarDuration.Short
+                                            )
+                                            if (result == SnackbarResult.ActionPerformed) {
+                                                navController.navigate("cart")
+                                            }
                                         }
-                                    }
-                                },
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                painter = painterResource(R.drawable.ic_icon_bag),
-                                contentDescription = "장바구니 담기",
-                                tint = Color.Black,
-                                modifier = Modifier.size(20.dp)
-                            )
+                                    },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Icon(
+                                    painter = painterResource(R.drawable.ic_icon_bag),
+                                    contentDescription = "장바구니 담기",
+                                    tint = Color.Black,
+                                    modifier = Modifier.size(20.dp)
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
@@ -36,6 +36,7 @@ import androidx.navigation.NavController
 import com.refit.app.R
 import com.refit.app.data.cart.modelAndView.CartEditViewModel
 import com.refit.app.data.me.modelAndView.OrderViewModel
+import com.refit.app.util.common.PriceUtil
 import com.refit.app.util.order.OrderStatusMapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -132,6 +133,7 @@ fun RecentOrderSection(
                 }
 
                 Spacer(Modifier.height(8.dp))
+                HorizontalDivider(thickness = 1.dp, color = Color.LightGray)
 
                 order.items.forEach { item ->
                     Row(
@@ -168,27 +170,30 @@ fun RecentOrderSection(
                                 )
                                 Row {
                                     Text(
-                                        text = "${item.price}원",
+                                        text = PriceUtil.formatPrice(item.price.toLong()),
                                         fontSize = 13.sp,
                                         fontWeight = FontWeight.Bold,
-                                        fontFamily = Pretendard
+                                        fontFamily = Pretendard,
+                                        modifier = Modifier.alignByBaseline()
                                     )
                                     if (item.originalPrice > item.price) {
                                         Spacer(Modifier.width(6.dp))
                                         Text(
-                                            text = "${item.originalPrice}원",
+                                            text = PriceUtil.formatPrice(item.originalPrice.toLong()),
                                             fontSize = 12.sp,
                                             fontFamily = Pretendard,
                                             color = Color.Gray,
-                                            textDecoration = TextDecoration.LineThrough
+                                            textDecoration = TextDecoration.LineThrough,
+                                            modifier = Modifier.alignByBaseline()
                                         )
                                     }
                                     Spacer(Modifier.width(6.dp))
                                     Text(
-                                        text = "수량:${item.quantity}",
+                                        text = "| ${item.quantity}개",
                                         fontSize = 12.sp,
                                         fontFamily = Pretendard,
-                                        color = Color.Gray
+                                        color = Color.Gray,
+                                        modifier = Modifier.alignByBaseline()
                                     )
                                 }
 
@@ -273,7 +278,17 @@ fun RecentOrderSection(
                                 .clickable {
                                     cartVm.addOne(item.productId, 1)
                                     scope.launch {
-                                        snackbarHostState.showSnackbar("${item.productName}이 장바구니에 추가되었습니다.")
+                                        snackbarHostState.currentSnackbarData?.dismiss()
+
+                                        val result = snackbarHostState.showSnackbar(
+                                            message = "${item.productName}을 장바구니에 담았어요.",
+                                            actionLabel = "바로가기",
+                                            withDismissAction = true,
+                                            duration = SnackbarDuration.Short
+                                        )
+                                        if (result == SnackbarResult.ActionPerformed) {
+                                            navController.navigate("cart")
+                                        }
                                     }
                                 },
                             contentAlignment = Alignment.Center
@@ -286,7 +301,6 @@ fun RecentOrderSection(
                             )
                         }
                     }
-                    HorizontalDivider(thickness = 1.dp, color = Color.LightGray)
                 }
             }
         }

--- a/app/src/main/java/com/refit/app/ui/screen/CombinationRegisterScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/CombinationRegisterScreen.kt
@@ -37,13 +37,16 @@ fun CombinationRegisterScreen(
     selectedProducts: List<Product> = emptyList(),
     onSearchClick: (String) -> Unit = {},
     vm: CombinationRegisterViewModel = viewModel(),
-    onRegisterSuccess: () -> Unit = {}
+    onRegisterSuccess: () -> Unit = {},
+    defaultType: String = "beauty"
 ) {
     val uiState by vm.state.collectAsState()
     val scrollState = rememberScrollState()
+    var nameError by remember { mutableStateOf<String?>(null) }
+    var descriptionError by remember { mutableStateOf<String?>(null) }
+    var productError by remember { mutableStateOf<String?>(null) }
 
     val snackbarHostState = remember { SnackbarHostState() }
-    val scope = rememberCoroutineScope()
 
     val backStackEntry by navController.currentBackStackEntryAsState()
     val savedProducts =
@@ -51,7 +54,7 @@ fun CombinationRegisterScreen(
             ?.collectAsState() ?: remember { mutableStateOf(emptyList()) }
 
     // 타입 상태
-    var type by rememberSaveable { mutableStateOf<String?>(null) }
+    var type by rememberSaveable { mutableStateOf<String?>(defaultType) }
 
     // 상품 리스트 상태
     var products by remember { mutableStateOf(selectedProducts) }
@@ -66,15 +69,12 @@ fun CombinationRegisterScreen(
     var showDialog by remember { mutableStateOf(false) }
     var pendingType by remember { mutableStateOf<String?>(null) }
 
-    val isTypeValid = type != null
-    val isNameValid = name.isNotBlank()
-    val isProductsValid = products.size in 2..6
-    val isDescriptionValid = description.length >= 10
-    val isFormValid = isTypeValid && isNameValid && isProductsValid && isDescriptionValid
+    val displayOptions = listOf("뷰티" to "beauty", "헬스" to "health")
 
     Scaffold(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState) },
-        containerColor = Color.White
+        containerColor = Color.White,
+        modifier = Modifier.imePadding()
     ) { innerPadding ->
         Column(
             modifier = Modifier
@@ -95,37 +95,38 @@ fun CombinationRegisterScreen(
                 fontFamily = Pretendard
             )
             Spacer(modifier = Modifier.height(8.dp))
+
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                listOf("뷰티", "헬스").forEach { option ->
+                displayOptions.forEach { (label, value) ->
                     Box(
                         modifier = Modifier
                             .weight(1f)
                             .height(40.dp)
                             .border(
                                 1.dp,
-                                if (type == option) MainPurple else Color.LightGray,
+                                if (type == value) MainPurple else Color.LightGray,
                                 RoundedCornerShape(8.dp)
                             )
                             .background(
-                                if (type == option) MainPurple.copy(alpha = 0.1f) else Color.White,
+                                if (type == value) MainPurple.copy(alpha = 0.1f) else Color.White,
                                 RoundedCornerShape(8.dp)
                             )
                             .clickable {
-                                if (type == null || type == option) {
-                                    type = option
+                                if (type == null || type == value) {
+                                    type = value
                                 } else {
-                                    pendingType = option
+                                    pendingType = value
                                     showDialog = true
                                 }
                             },
                         contentAlignment = Alignment.Center
                     ) {
                         Text(
-                            text = option,
+                            text = label,
                             fontSize = 14.sp,
                             fontFamily = Pretendard,
-                            fontWeight = if (type == option) FontWeight.Bold else FontWeight.Normal,
-                            color = if (type == option) MainPurple else Color.Black
+                            fontWeight = if (type == value) FontWeight.Bold else FontWeight.Normal,
+                            color = if (type == value) MainPurple else Color.Black
                         )
                     }
                 }
@@ -140,14 +141,20 @@ fun CombinationRegisterScreen(
                 fontWeight = FontWeight.Medium,
                 fontFamily = Pretendard
             )
+
             Spacer(modifier = Modifier.height(8.dp))
+
             OutlinedTextField(
                 value = name,
-                onValueChange = { name = it },
+                onValueChange = {
+                    name = it
+                    nameError = null
+                },
                 placeholder = { Text("조합명 입력", fontFamily = Pretendard) },
                 modifier = Modifier.fillMaxWidth()
             )
-            if (name.isBlank()) {
+
+            if (!nameError.isNullOrBlank()) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.padding(top = 4.dp, start = 4.dp)
@@ -160,7 +167,7 @@ fun CombinationRegisterScreen(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = "조합명은 필수입니다.",
+                        text = nameError ?: "",
                         fontSize = 12.sp,
                         color = MainPurple,
                         fontFamily = Pretendard
@@ -179,18 +186,23 @@ fun CombinationRegisterScreen(
             )
             Spacer(modifier = Modifier.height(8.dp))
 
+            // 상품 검색 버튼
             Button(
                 onClick = {
-                    val bh = if (type == "뷰티") "beauty" else "health"
-                    onSearchClick(bh)
+                    if (name.isBlank()) {
+                        nameError = "조합명은 필수입니다."
+                    } else {
+                        val bh = type ?: "beauty"
+                        navController.currentBackStackEntry
+                            ?.savedStateHandle
+                            ?.set("preSelectedProducts", products)
+                        onSearchClick(bh)
+                    }
                 },
-                enabled = type != null,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(50.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = if (type != null) MainPurple else Color.LightGray
-                ),
+                colors = ButtonDefaults.buttonColors(containerColor = MainPurple),
                 shape = RoundedCornerShape(8.dp)
             ) {
                 Text(
@@ -240,19 +252,19 @@ fun CombinationRegisterScreen(
             Spacer(modifier = Modifier.height(8.dp))
             OutlinedTextField(
                 value = description,
-                onValueChange = { description = it },
+                onValueChange = {
+                    description = it
+                    descriptionError = null
+                },
                 placeholder = {
-                    Text(
-                        "조합을 사용한 기간, 사용 후 변화 등을 자유롭게 작성해주세요!",
-                        fontFamily = Pretendard
-                    )
+                    Text("조합을 사용한 기간, 사용 후 변화 등을 자유롭게 작성해주세요!", fontFamily = Pretendard)
                 },
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(120.dp)
             )
 
-            if (description.isBlank()) {
+            if (!descriptionError.isNullOrBlank()) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier.padding(top = 4.dp, start = 4.dp)
@@ -265,26 +277,7 @@ fun CombinationRegisterScreen(
                     )
                     Spacer(modifier = Modifier.width(4.dp))
                     Text(
-                        text = "조합 설명은 필수입니다.",
-                        fontSize = 12.sp,
-                        color = MainPurple,
-                        fontFamily = Pretendard
-                    )
-                }
-            } else if (description.length in 1..9) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    modifier = Modifier.padding(top = 4.dp, start = 4.dp)
-                ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_exclamation_fill),
-                        contentDescription = null,
-                        tint = Color.Unspecified,
-                        modifier = Modifier.size(16.dp)
-                    )
-                    Spacer(modifier = Modifier.width(4.dp))
-                    Text(
-                        text = "설명에는 최소 10자 이상을 남겨주세요!",
+                        text = descriptionError ?: "",
                         fontSize = 12.sp,
                         color = MainPurple,
                         fontFamily = Pretendard
@@ -297,35 +290,63 @@ fun CombinationRegisterScreen(
             // 등록 버튼
             Button(
                 onClick = {
-                    val ids = products.map { it.id.toLong() }
-                    val req = CreateCombinationRequest(
-                        name = name,
-                        content = description,
-                        type = if (type == "뷰티") "beauty" else "health",
-                        product1Id = ids[0],
-                        product2Id = ids[1],
-                        product3Id = ids.getOrNull(2),
-                        product4Id = ids.getOrNull(3),
-                        product5Id = ids.getOrNull(4),
-                        product6Id = ids.getOrNull(5)
-                    )
-                    vm.registerCombination(req)
+                    when {
+                        name.isBlank() -> {
+                            nameError = "조합명은 필수입니다."
+                        }
+                        products.size < 2 -> {
+                            productError = "상품을 최소 2개 이상 선택해주세요."
+                        }
+                        description.length < 5 -> {
+                            descriptionError = "조합에 대한 설명을 최소 5자 이상 적어주세요."
+                        }
+                        else -> {
+                            val ids = products.map { it.id.toLong() }
+                            val req = CreateCombinationRequest(
+                                name = name,
+                                content = description,
+                                type = type ?: "beauty",
+                                product1Id = ids[0],
+                                product2Id = ids[1],
+                                product3Id = ids.getOrNull(2),
+                                product4Id = ids.getOrNull(3),
+                                product5Id = ids.getOrNull(4),
+                                product6Id = ids.getOrNull(5)
+                            )
+                            vm.registerCombination(req)
+                        }
+                    }
                 },
-                enabled = isFormValid && !uiState.isLoading,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(50.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = if (isFormValid) MainPurple else Color.LightGray
-                ),
+                colors = ButtonDefaults.buttonColors(containerColor = MainPurple),
                 shape = RoundedCornerShape(8.dp)
             ) {
-                Text(
-                    if (uiState.isLoading) "등록 중..." else "등록하기",
-                    fontWeight = FontWeight.Bold,
-                    color = Color.White,
-                    fontFamily = Pretendard
-                )
+                Text(if (uiState.isLoading) "등록 중..." else "등록하기",
+                    fontWeight = FontWeight.Bold, color = Color.White, fontFamily = Pretendard)
+            }
+
+            // 공통 에러 메시지
+            if (!productError.isNullOrBlank()) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier.padding(top = 8.dp, start = 4.dp)
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic_exclamation_fill),
+                        contentDescription = null,
+                        tint = Color.Unspecified,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = productError ?: "",
+                        fontSize = 12.sp,
+                        color = MainPurple,
+                        fontFamily = Pretendard
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/refit/app/ui/screen/CreatedCombinationListScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/CreatedCombinationListScreen.kt
@@ -1,7 +1,7 @@
 package com.refit.app.ui.screen
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
@@ -9,10 +9,17 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.refit.app.R
 import com.refit.app.data.me.modelAndView.MyCombinationViewModel
 import com.refit.app.ui.composable.combination.CombinationCard
+import com.refit.app.ui.theme.Pretendard
+import androidx.compose.ui.graphics.Color
 
 @Composable
 fun CreatedCombinationListScreen(
@@ -35,6 +42,31 @@ fun CreatedCombinationListScreen(
         state.error != null -> {
             Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                 Text("에러: ${state.error}")
+            }
+        }
+
+        state.combinations.isEmpty() -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.jellbbo_default),
+                        contentDescription = "생성한 조합 없음",
+                        modifier = Modifier.size(120.dp)
+                    )
+                    Text(
+                        text = "아직 생성한 조합이 없어요.",
+                        fontFamily = Pretendard,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 15.sp,
+                        color = Color.Gray
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/com/refit/app/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/HomeScreen.kt
@@ -73,7 +73,6 @@ fun HomeScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .verticalScroll(scroll)
-                .padding(bottom = 100.dp)
         ) {
             // ===== 나만의 정보 섹션 =====
             Column(
@@ -94,7 +93,7 @@ fun HomeScreen(
                         MetricItem(
                             "오늘의 걸음수",
                             uiState.steps?.takeIf { it > 0 }?.toString() ?: "--",
-                            "보",
+                            "걸음",
                             R.drawable.jellbbo_walk,
                             iconOffsetY = -20,
                             onClick = { navController.navigate("stepsDetail") }

--- a/app/src/main/java/com/refit/app/ui/screen/HomeScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/HomeScreen.kt
@@ -34,7 +34,6 @@ import com.refit.app.data.home.modelAndView.HomeViewModel
 import com.refit.app.network.UserPrefs
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
-import com.refit.app.network.TokenManager
 import com.refit.app.util.home.getWeatherIcon
 import com.refit.app.util.home.highlightText
 

--- a/app/src/main/java/com/refit/app/ui/screen/LikedCombinationListScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/LikedCombinationListScreen.kt
@@ -1,7 +1,6 @@
 package com.refit.app.ui.screen
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.CircularProgressIndicator
@@ -9,14 +8,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
+import com.refit.app.R
 import com.refit.app.data.local.combination.MyCombinationStore
 import com.refit.app.data.combination.modelAndView.LikedCombinationViewModel
 import com.refit.app.ui.composable.combination.CombinationCard
 import com.refit.app.ui.theme.Pretendard
 import kotlinx.coroutines.launch
+import androidx.compose.foundation.Image
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 
 @Composable
 fun LikedCombinationListScreen(
@@ -30,9 +36,10 @@ fun LikedCombinationListScreen(
     val savedIds by myCombinationStore.savedIds.collectAsState(initial = emptySet())
     val scope = rememberCoroutineScope()
 
-    // MyCombinationStore에 저장된 combinationId 기반으로 조회
     LaunchedEffect(savedIds) {
-        if (savedIds.isNotEmpty()) {
+        if (savedIds.isEmpty()) {
+            vm.clearLikedCombinations()
+        } else {
             vm.loadLikedCombinations(savedIds)
         }
     }
@@ -50,6 +57,31 @@ fun LikedCombinationListScreen(
             }
         }
 
+        state.combinations.isEmpty() -> {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.jellbbo_default),
+                        contentDescription = "저장한 조합 없음",
+                        modifier = Modifier.size(120.dp)
+                    )
+                    Text(
+                        text = "아직 저장한 조합이 없어요.",
+                        fontFamily = Pretendard,
+                        fontWeight = FontWeight.SemiBold,
+                        fontSize = 15.sp,
+                        color = Color.Gray
+                    )
+                }
+            }
+        }
+
         else -> {
             LazyColumn {
                 items(state.combinations) { combination ->
@@ -59,11 +91,7 @@ fun LikedCombinationListScreen(
                         onToggleSave = { id ->
                             scope.launch {
                                 val wasSaved = savedIds.contains(id)
-
-                                // SharedPreference에서 제거
                                 myCombinationStore.toggle(id)
-
-                                // 서버에도 반영
                                 if (wasSaved) {
                                     vm.dislikeCombination(id)
                                 } else {

--- a/app/src/main/java/com/refit/app/ui/screen/MypageScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/MypageScreen.kt
@@ -83,21 +83,20 @@ fun MypageScreen(
 
                 Spacer(Modifier.height(12.dp))
 
-                state.orders?.recentOrder
+                val latestOrder = state.orders?.recentOrder
                     ?.maxByOrNull { order -> order.items.maxOfOrNull { it.createdAt } ?: "" }
-                    ?.let { latestOrder ->
-                        RecentOrderSection(
-                            order = latestOrder,
-                            onClickAll = { navController.navigate("orders") },
-                            vm = vm,
-                            cartVm = cartVm,
-                            onCartChanged = onCartChanged,
-                            navController = navController,
-                            snackbarHostState = snackbarHostState,
-                            scope = scope
-                        )
-                        Spacer(Modifier.height(12.dp))
-                    }
+
+                RecentOrderSection(
+                    order = latestOrder,
+                    onClickAll = { navController.navigate("orders") },
+                    vm = vm,
+                    cartVm = cartVm,
+                    onCartChanged = onCartChanged,
+                    navController = navController,
+                    snackbarHostState = snackbarHostState,
+                    scope = scope
+                )
+                Spacer(Modifier.height(12.dp))
 
                 MypageMenuSection(navController = navController)
             }

--- a/app/src/main/java/com/refit/app/ui/screen/OrderListScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/OrderListScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -32,6 +31,8 @@ import com.refit.app.ui.composable.mypage.OrderItemRow
 import com.refit.app.ui.theme.LightPurple
 import com.refit.app.ui.theme.Pretendard
 import kotlinx.coroutines.launch
+import androidx.compose.ui.res.painterResource
+import com.refit.app.R
 
 @Composable
 fun OrderListScreen(
@@ -90,44 +91,72 @@ fun OrderListScreen(
             }
 
             state.orders != null -> {
-                LazyColumn(
-                    state = listState,
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(LightPurple),
-                    contentPadding = PaddingValues(12.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp)
-                ) {
-                    items(state.orders!!.recentOrder) { order ->
-                        Card(
-                            modifier = Modifier.fillMaxWidth(),
-                            shape = RoundedCornerShape(12.dp),
-                            colors = CardDefaults.cardColors(containerColor = Color.White)
+                if (state.orders!!.recentOrder.isEmpty()) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(LightPurple),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
                         ) {
-                            Column(modifier = Modifier.padding(16.dp)) {
-                                val firstItem = order.items.firstOrNull()
-                                if (firstItem != null) {
-                                    val date = firstItem.createdAt.take(10).replace("-", ".")
-                                    Text(date, fontFamily = Pretendard, fontWeight = FontWeight.Bold,
-                                        fontSize = 15.sp, color = Color.Black)
-                                    Text("주문번호 ${firstItem.orderCode}", fontFamily = Pretendard,
-                                        fontSize = 13.sp, color = Color.Gray)
-                                    Spacer(Modifier.height(12.dp))
-                                    HorizontalDivider(color = Color(0xFFE0E0E0), thickness = 1.dp)
-                                    Spacer(Modifier.height(12.dp))
-                                }
+                            Icon(
+                                painter = painterResource(id = R.drawable.jellbbo_default),
+                                contentDescription = "주문 내역 없음",
+                                tint = Color.Unspecified,
+                                modifier = Modifier.size(120.dp)
+                            )
+                            Text(
+                                text = "아직 주문 내역이 없어요.",
+                                fontFamily = Pretendard,
+                                fontWeight = FontWeight.SemiBold,
+                                fontSize = 15.sp,
+                                color = Color.Gray
+                            )
+                        }
+                    }
+                } else {
+                    LazyColumn(
+                        state = listState,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(LightPurple),
+                        contentPadding = PaddingValues(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
+                    ) {
+                        items(state.orders!!.recentOrder) { order ->
+                            Card(
+                                modifier = Modifier.fillMaxWidth(),
+                                shape = RoundedCornerShape(12.dp),
+                                colors = CardDefaults.cardColors(containerColor = Color.White)
+                            ) {
+                                Column(modifier = Modifier.padding(16.dp)) {
+                                    val firstItem = order.items.firstOrNull()
+                                    if (firstItem != null) {
+                                        val date = firstItem.createdAt.take(10).replace("-", ".")
+                                        Text(date, fontFamily = Pretendard, fontWeight = FontWeight.Bold,
+                                            fontSize = 15.sp, color = Color.Black)
+                                        Text("주문번호 ${firstItem.orderCode}", fontFamily = Pretendard,
+                                            fontSize = 13.sp, color = Color.Gray)
+                                        Spacer(Modifier.height(12.dp))
+                                        HorizontalDivider(color = Color(0xFFE0E0E0), thickness = 1.dp)
+                                        Spacer(Modifier.height(12.dp))
+                                    }
 
-                                order.items.forEach { item ->
-                                    OrderItemRow(
-                                        item = item,
-                                        vm = vm,
-                                        cartVm = cartVm,
-                                        onCartChanged = onCartChanged,
-                                        navController = navController,
-                                        snackbarHostState = snackbarHostState,
-                                        scope = scope
-                                    )
-                                    Spacer(Modifier.height(12.dp))
+                                    order.items.forEach { item ->
+                                        OrderItemRow(
+                                            item = item,
+                                            vm = vm,
+                                            cartVm = cartVm,
+                                            onCartChanged = onCartChanged,
+                                            navController = navController,
+                                            snackbarHostState = snackbarHostState,
+                                            scope = scope
+                                        )
+                                        Spacer(Modifier.height(12.dp))
+                                    }
                                 }
                             }
                         }
@@ -155,8 +184,8 @@ fun OrderListScreen(
         message = cancelSuccessMessage,
         onConfirm = {
             showCancelSuccess = false
-            // 필요하면 목록 갱신
             vm.loadOrders()
         }
     )
 }
+

--- a/app/src/main/java/com/refit/app/ui/screen/ProductSelectScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/ProductSelectScreen.kt
@@ -63,8 +63,13 @@ fun ProductSelectScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
 
-    var selectedProducts by remember { mutableStateOf(listOf<Product>()) }
-    val isValid = selectedProducts.size in 2..6
+    val preSelectedProducts =
+        navController.previousBackStackEntry
+            ?.savedStateHandle
+            ?.get<List<Product>>("preSelectedProducts")
+
+    var selectedProducts by remember { mutableStateOf(preSelectedProducts ?: emptyList()) }
+    var showCountErrorDialog by remember { mutableStateOf(false) }
 
     val listState = rememberLazyListState()
 
@@ -87,20 +92,23 @@ fun ProductSelectScreen(
         bottomBar = {
             Button(
                 onClick = {
-                    navController.previousBackStackEntry
-                        ?.savedStateHandle
-                        ?.set("selectedProducts", selectedProducts)
-                    navController.popBackStack()
+                    if (selectedProducts.size !in 2..6) {
+                        scope.launch {
+                            snackbarHostState.showSnackbar("상품은 2개 이상 6개 이하로 선택해야 합니다.")
+                        }
+                    } else {
+                        navController.previousBackStackEntry
+                            ?.savedStateHandle
+                            ?.set("selectedProducts", selectedProducts)
+                        navController.popBackStack()
+                    }
                 },
-                enabled = isValid,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(16.dp)
                     .height(52.dp),
                 shape = RoundedCornerShape(12.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = if (isValid) MainPurple else Color.LightGray
-                )
+                colors = ButtonDefaults.buttonColors(containerColor = MainPurple) // 항상 보라색
             ) {
                 Text(
                     "선택완료",

--- a/app/src/main/java/com/refit/app/ui/screen/SleepDetilScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/SleepDetilScreen.kt
@@ -46,12 +46,12 @@ fun SleepDetailScreen(
         }
     }
 
-    // 어제까지 데이터
-    val yesterdayRows = if (rows.size > 1) rows.dropLast(1) else rows
-    val yesterdaySleep = yesterdayRows.lastOrNull()?.sleepMinutes ?: 0
-    val avgSleep = yesterdayRows.mapNotNull { it.sleepMinutes }.average().toInt()
-    val minSleep = yesterdayRows.mapNotNull { it.sleepMinutes }.minOrNull() ?: 0
-    val maxSleep = yesterdayRows.mapNotNull { it.sleepMinutes }.maxOrNull() ?: 0
+    // 데이터
+    val allRows = rows
+    val yesterdaySleep = allRows.lastOrNull()?.sleepMinutes ?: 0
+    val avgSleep = allRows.mapNotNull { it.sleepMinutes }.average().toInt()
+    val minSleep = allRows.mapNotNull { it.sleepMinutes }.minOrNull() ?: 0
+    val maxSleep = allRows.mapNotNull { it.sleepMinutes }.maxOrNull() ?: 0
 
     // 한국 평균 & 권장 수면시간
     val koreanAvgSleep = 387    // 6시간 27분
@@ -76,7 +76,7 @@ fun SleepDetailScreen(
 
         Spacer(Modifier.height(16.dp))
 
-        if (yesterdayRows.isEmpty()) {
+        if (allRows.isEmpty()) {
             Text("수면 데이터가 아직 없어요.", style = MaterialTheme.typography.bodyMedium.copy(fontFamily = Pretendard))
             return
         }
@@ -96,7 +96,7 @@ fun SleepDetailScreen(
             modifier = Modifier.fillMaxWidth().height(220.dp),
             factory = { ctx ->
                 MpLineChart(ctx).apply {
-                    val entries = yesterdayRows.mapIndexed { idx, row ->
+                    val entries = allRows.mapIndexed { idx, row ->
                         Entry(idx.toFloat(), (row.sleepMinutes ?: 0).toFloat())
                     }
                     data = LineData(LineDataSet(entries, "수면시간").apply {
@@ -122,10 +122,14 @@ fun SleepDetailScreen(
                     axisLeft.setDrawGridLines(false)
                     legend.isEnabled = true
 
+                    val totalSize = allRows.size
                     xAxis.valueFormatter = object : ValueFormatter() {
                         override fun getFormattedValue(value: Float): String {
-                            val dayOffset = yesterdayRows.size - value.toInt()
-                            return if (dayOffset > 0) "${dayOffset}일 전" else "어제"
+                            val index = value.toInt()
+                            return when (index) {
+                                totalSize - 1 -> "오늘"
+                                else -> "${totalSize - 1 - index}일 전"
+                            }
                         }
                     }
                     axisLeft.valueFormatter = object : ValueFormatter() {

--- a/app/src/main/java/com/refit/app/ui/screen/StepsDetailScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/StepsDetailScreen.kt
@@ -1,7 +1,6 @@
 package com.refit.app.ui.screen
 
 import android.graphics.Color
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
@@ -19,9 +18,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
-import com.github.mikephil.charting.charts.LineChart as MpLineChart
 import com.github.mikephil.charting.data.*
 import com.github.mikephil.charting.formatter.IndexAxisValueFormatter
+import com.github.mikephil.charting.formatter.ValueFormatter
 import com.refit.app.R
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
@@ -30,6 +29,10 @@ import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.HealthConnectClient
 import com.refit.app.data.health.HealthRepo
 import com.github.mikephil.charting.components.Legend
+import com.refit.app.ui.composable.health.RoundedBarChartRenderer
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
 
 @Composable
 fun StepsDetailScreen(
@@ -40,26 +43,20 @@ fun StepsDetailScreen(
     val rows = uiState.rows
     val context = LocalContext.current
 
-    // 권한 요청 런처
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = PermissionController.createRequestPermissionResultContract()
     ) { granted ->
         val allGranted = HealthRepo.readPerms.all { granted.contains(it) }
         if (allGranted) {
-            Log.d("StepsDetailScreen", "권한 허용 완료 → fetch 호출")
             vm.onPermissionGranted(context)
             vm.onDaysChanged(context, 7)
-        } else {
-            Log.w("StepsDetailScreen", "권한 거부됨")
         }
     }
 
-    // 화면 진입 시 실행
     LaunchedEffect(Unit) {
         val healthConnectClient = HealthConnectClient.getOrCreate(context)
         val granted = healthConnectClient.permissionController.getGrantedPermissions()
         if (HealthRepo.readPerms.all { granted.contains(it) }) {
-            Log.d("StepsDetailScreen", "이미 권한 있음 → fetch 호출")
             vm.onPermissionGranted(context)
             vm.onDaysChanged(context, 7)
         } else {
@@ -67,17 +64,13 @@ fun StepsDetailScreen(
         }
     }
 
-    // ====== 화면 레이아웃 ======
     Column(
         modifier = Modifier
             .fillMaxSize()
             .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
-        // 제목 + 마스코트 아이콘
-        Row(
-            verticalAlignment = Alignment.CenterVertically
-        ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
             Image(
                 painter = painterResource(id = R.drawable.jellbbo_doctor),
                 contentDescription = "타이틀 젤뽀",
@@ -96,139 +89,152 @@ fun StepsDetailScreen(
 
         val todaySteps = rows.lastOrNull()?.steps ?: 0L
         val todayKcal = rows.lastOrNull()?.totalKcal ?: 0.0
-        val avgSteps = rows.mapNotNull { it.steps }.average().toInt()
-        val avgKcal = rows.mapNotNull { it.totalKcal }.average().toInt()
 
-        val xLabels = rows.mapIndexed { idx, _ ->
-            if (idx == rows.size - 1) "오늘"
-            else "${rows.size - 1 - idx}일전"
+        val today = LocalDate.now()
+        val days = (6 downTo 0).map { today.minusDays(it.toLong()) }
+        val xLabels = days.map {
+            if (it == today) "오늘"
+            else it.dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.KOREAN)
         }
+
+        // rows와 days를 맞춰 정렬
+        val sortedData = days.zip(rows.takeLast(7)).reversed()
+        val stepEntries = sortedData.mapIndexed { idx, pair -> BarEntry(idx.toFloat(), (pair.second.steps ?: 0L).toFloat()) }
+        val kcalEntries = sortedData.mapIndexed { idx, pair -> BarEntry(idx.toFloat(), (pair.second.totalKcal ?: 0.0).toFloat()) }
+
         val indexFormatter = IndexAxisValueFormatter(xLabels)
 
-        // ========== 1번째 차트: 최근 걸음수 ==========
+        // ========== 1번째 차트 ==========
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Image(
-                painter = painterResource(id = R.drawable.jellbbo_walk),
-                contentDescription = null,
-                modifier = Modifier.size(24.dp)
-            )
+            Image(painter = painterResource(id = R.drawable.jellbbo_walk), contentDescription = null, modifier = Modifier.size(24.dp))
             Spacer(modifier = Modifier.width(6.dp))
-            Text("7일간의 내 걸음", style = MaterialTheme.typography.bodyLarge.copy(fontFamily = Pretendard))
+            Text("7일간의 내 걸음 (단위: 걸음)", style = MaterialTheme.typography.bodyLarge.copy(fontFamily = Pretendard))
         }
         Spacer(Modifier.height(8.dp))
         AndroidView(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(220.dp),
+            modifier = Modifier.fillMaxWidth().height(220.dp),
             factory = { ctx ->
-                MpLineChart(ctx).apply {
-                    val entries = rows.mapIndexed { idx, row ->
-                        Entry(idx.toFloat(), (row.steps ?: 0L).toFloat())
-                    }
-                    val dataSet = LineDataSet(entries, "걸음수").apply {
-                        color = MainPurple.toArgb()
+                com.github.mikephil.charting.charts.BarChart(ctx).apply {
+                    val barDataSet = BarDataSet(stepEntries, "").apply {
+                        setDrawValues(true)
                         valueTextColor = Color.DKGRAY
-                        lineWidth = 2f
-                        setDrawCircles(true)
-                        setCircleColor(MainPurple.toArgb())
+                        valueTextSize = 12f
+                        colors = stepEntries.mapIndexed { idx, _ -> if (idx == stepEntries.size - 1) MainPurple.toArgb() else Color.LTGRAY }
+                        valueFormatter = object : ValueFormatter() {
+                            override fun getBarLabel(barEntry: BarEntry?): String = "${barEntry?.y?.toInt()}"
+                        }
                     }
-                    data = LineData(dataSet)
+                    data = BarData(barDataSet).apply { barWidth = 0.4f }
+                    renderer = RoundedBarChartRenderer(this, animator, viewPortHandler)
                     description.isEnabled = false
+                    legend.isEnabled = false
+                    axisLeft.isEnabled = false
                     axisRight.isEnabled = false
-                    axisLeft.setDrawGridLines(false)
-
-                    xAxis.granularity = 1f
-                    xAxis.setDrawGridLines(false)
-                    xAxis.valueFormatter = indexFormatter
+                    xAxis.apply {
+                        position = com.github.mikephil.charting.components.XAxis.XAxisPosition.BOTTOM
+                        setDrawGridLines(false)
+                        granularity = 1f
+                        valueFormatter = indexFormatter
+                        textColor = Color.DKGRAY
+                    }
                 }
             }
         )
 
         Spacer(Modifier.height(32.dp))
 
-        // ========== 2번째 차트: 최근 소비 칼로리 ==========
+        // ========== 2번째 차트 ==========
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Image(
-                painter = painterResource(id = R.drawable.jellbbo_walk),
-                contentDescription = null,
-                modifier = Modifier.size(24.dp)
-            )
+            Image(painter = painterResource(id = R.drawable.jellbbo_walk), contentDescription = null, modifier = Modifier.size(24.dp))
             Spacer(modifier = Modifier.width(6.dp))
-            Text("7일간의 칼로리 소모", style = MaterialTheme.typography.bodyLarge.copy(fontFamily = Pretendard))
+            Text("7일간의 칼로리 소모 (단위: kcal)", style = MaterialTheme.typography.bodyLarge.copy(fontFamily = Pretendard))
         }
         Spacer(Modifier.height(8.dp))
         AndroidView(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(220.dp),
+            modifier = Modifier.fillMaxWidth().height(220.dp),
             factory = { ctx ->
-                MpLineChart(ctx).apply {
-                    val entries = rows.mapIndexed { idx, row ->
-                        Entry(idx.toFloat(), (row.totalKcal ?: 0.0).toFloat())
-                    }
-                    val dataSet = LineDataSet(entries, "소모 칼로리(kcal)").apply {
-                        color = MainPurple.toArgb()
+                com.github.mikephil.charting.charts.BarChart(ctx).apply {
+                    val barDataSet = BarDataSet(kcalEntries, "").apply {
+                        setDrawValues(true)
                         valueTextColor = Color.DKGRAY
-                        lineWidth = 2f
-                        setDrawCircles(true)
-                        setCircleColor(MainPurple.toArgb())
+                        valueTextSize = 12f
+                        colors = kcalEntries.mapIndexed { idx, _ -> if (idx == kcalEntries.size - 1) MainPurple.toArgb() else Color.LTGRAY }
+                        valueFormatter = object : ValueFormatter() {
+                            override fun getBarLabel(barEntry: BarEntry?): String = "${barEntry?.y?.toInt()}"
+                        }
                     }
-                    data = LineData(dataSet)
+                    data = BarData(barDataSet).apply { barWidth = 0.4f }
+                    renderer = RoundedBarChartRenderer(this, animator, viewPortHandler)
                     description.isEnabled = false
+                    legend.isEnabled = false
+                    axisLeft.isEnabled = false
                     axisRight.isEnabled = false
-                    axisLeft.setDrawGridLines(false)
-
-                    xAxis.granularity = 1f
-                    xAxis.setDrawGridLines(false)
-                    xAxis.valueFormatter = indexFormatter
+                    xAxis.apply {
+                        position = com.github.mikephil.charting.components.XAxis.XAxisPosition.BOTTOM
+                        setDrawGridLines(false)
+                        granularity = 1f
+                        valueFormatter = indexFormatter
+                        textColor = Color.DKGRAY
+                    }
                 }
             }
         )
 
         Spacer(Modifier.height(32.dp))
 
-        // ========== 3번째 차트: 한국인 평균 걸음 비교 ==========
+        // ========== 3번째 차트 ==========
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Image(
-                painter = painterResource(id = R.drawable.jellbbo_walk),
-                contentDescription = null,
-                modifier = Modifier.size(24.dp)
-            )
+            Image(painter = painterResource(id = R.drawable.jellbbo_walk), contentDescription = null, modifier = Modifier.size(24.dp))
             Spacer(modifier = Modifier.width(6.dp))
-            Text("오늘 걸음 수 vs 한국인 평균", style = MaterialTheme.typography.bodyLarge.copy(fontFamily = Pretendard))
+            Text("오늘 걸음 수 vs 한국인 평균 (단위: 걸음)", style = MaterialTheme.typography.bodyLarge.copy(fontFamily = Pretendard))
         }
         Spacer(Modifier.height(8.dp))
         AndroidView(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(200.dp),
+            modifier = Modifier.fillMaxWidth().height(200.dp),
             factory = { ctx ->
                 com.github.mikephil.charting.charts.BarChart(ctx).apply {
                     val my = BarEntry(0f, todaySteps.toFloat())
                     val koreanAvg = BarEntry(1f, 9611f)
 
-                    val mySet = BarDataSet(listOf(my), "나의 오늘 걸음수").apply {
+                    val mySet = BarDataSet(listOf(my), "나").apply {
                         color = MainPurple.toArgb()
                         valueTextColor = Color.DKGRAY
+                        valueTextSize = 10f
+                        setDrawValues(true)
                     }
-                    val avgSet = BarDataSet(listOf(koreanAvg), "한국인 일평균 걸음수").apply {
+                    val avgSet = BarDataSet(listOf(koreanAvg), "한국인 평균").apply {
                         color = Color.LTGRAY
                         valueTextColor = Color.DKGRAY
+                        valueTextSize = 10f
+                        setDrawValues(true)
                     }
 
-                    data = BarData(mySet, avgSet)
-                    barData.barWidth = 0.4f
-                    groupBars(0f, 0.2f, 0f)
+                    val groupSpace = 0.4f
+                    val barSpace = 0.05f
+                    val barWidth = 0.2f
 
+                    data = BarData(mySet, avgSet).apply {
+                        this.barWidth = barWidth
+                    }
+
+                    val groupWidth = data.getGroupWidth(groupSpace, barSpace)
+                    xAxis.axisMinimum = 0f
+                    xAxis.axisMaximum = groupWidth
+                    groupBars(0f, groupSpace, barSpace)
+
+                    renderer = RoundedBarChartRenderer(this, animator, viewPortHandler)
                     description.isEnabled = false
                     axisRight.isEnabled = false
-                    xAxis.isEnabled = false
-                    axisLeft.setDrawGridLines(false)
+                    axisLeft.isEnabled = false
+                    xAxis.apply {
+                        isEnabled = false
+                        setDrawGridLines(false)
+                    }
 
                     legend.isEnabled = true
                     legend.form = Legend.LegendForm.SQUARE
                     legend.verticalAlignment = Legend.LegendVerticalAlignment.BOTTOM
-                    legend.horizontalAlignment = Legend.LegendHorizontalAlignment.LEFT
+                    legend.horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
                     legend.orientation = Legend.LegendOrientation.HORIZONTAL
                     legend.setDrawInside(false)
                 }
@@ -237,48 +243,59 @@ fun StepsDetailScreen(
 
         Spacer(Modifier.height(32.dp))
 
-        // ========== 4번째 차트: 한국인 평균 활동 칼로리 비교 ==========
+        // ========== 4번째 차트 ==========
         Row(verticalAlignment = Alignment.CenterVertically) {
-            Image(
-                painter = painterResource(id = R.drawable.jellbbo_walk),
-                contentDescription = null,
-                modifier = Modifier.size(24.dp)
-            )
+            Image(painter = painterResource(id = R.drawable.jellbbo_walk), contentDescription = null, modifier = Modifier.size(24.dp))
             Spacer(modifier = Modifier.width(6.dp))
-            Text("오늘 칼로리 소모량 vs 한국인 평균", style = MaterialTheme.typography.bodyLarge.copy(fontFamily = Pretendard))
+            Text("오늘 칼로리 소모량 vs 한국인 평균 (단위: kcal)", style = MaterialTheme.typography.bodyLarge.copy(fontFamily = Pretendard))
         }
         Spacer(Modifier.height(8.dp))
         AndroidView(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(200.dp),
+            modifier = Modifier.fillMaxWidth().height(200.dp),
             factory = { ctx ->
                 com.github.mikephil.charting.charts.BarChart(ctx).apply {
                     val my = BarEntry(0f, todayKcal.toFloat())
                     val koreanAvgKcal = BarEntry(1f, 350f)
 
-                    val mySet = BarDataSet(listOf(my), "오늘 총 소모 칼로리").apply {
+                    val mySet = BarDataSet(listOf(my), "나").apply {
                         color = MainPurple.toArgb()
                         valueTextColor = Color.DKGRAY
+                        valueTextSize = 10f
+                        setDrawValues(true)
                     }
-                    val avgSet = BarDataSet(listOf(koreanAvgKcal), "한국인 일평균 소모").apply {
+                    val avgSet = BarDataSet(listOf(koreanAvgKcal), "한국인 평균").apply {
                         color = Color.LTGRAY
                         valueTextColor = Color.DKGRAY
+                        valueTextSize = 10f
+                        setDrawValues(true)
                     }
 
-                    data = BarData(mySet, avgSet)
-                    barData.barWidth = 0.4f
-                    groupBars(0f, 0.2f, 0f)
+                    val groupSpace = 0.4f
+                    val barSpace = 0.05f
+                    val barWidth = 0.2f
 
+                    data = BarData(mySet, avgSet).apply {
+                        this.barWidth = barWidth
+                    }
+
+                    val groupWidth = data.getGroupWidth(groupSpace, barSpace)
+                    xAxis.axisMinimum = 0f
+                    xAxis.axisMaximum = groupWidth
+                    groupBars(0f, groupSpace, barSpace)
+
+                    renderer = RoundedBarChartRenderer(this, animator, viewPortHandler)
                     description.isEnabled = false
                     axisRight.isEnabled = false
-                    xAxis.isEnabled = false
-                    axisLeft.setDrawGridLines(false)
+                    axisLeft.isEnabled = false
+                    xAxis.apply {
+                        isEnabled = false
+                        setDrawGridLines(false)
+                    }
 
                     legend.isEnabled = true
                     legend.form = Legend.LegendForm.SQUARE
                     legend.verticalAlignment = Legend.LegendVerticalAlignment.BOTTOM
-                    legend.horizontalAlignment = Legend.LegendHorizontalAlignment.LEFT
+                    legend.horizontalAlignment = Legend.LegendHorizontalAlignment.CENTER
                     legend.orientation = Legend.LegendOrientation.HORIZONTAL
                     legend.setDrawInside(false)
                 }


### PR DESCRIPTION
## #️⃣ Issue Number
#81

## 📝 요약(Summary)
- 홈 화면 → 걸음으로 바꾸기 / 수면 시간 (0분은 안뜨게) / 해시태그 색 변경 (통일하게) / 맨 아래 간격 넓음
- 조합 → 전체 조합 가격 100원단위 체크 (백엔드)
- 조합 -> 기본 정렬은 최신순 / 상품 이미지 4개 꽉 채우기 (프론트)
- 프로필사진 → 안바뀜
- 마이페이지 → 화살표 닉네임 옆으로 옮기기 / 최근 주문내역에서 선 올리기
- 주문 내역 → 장바구니 추가 후, 장바구니 바로 가기 이동
- 조합 등록 → 이동 시, 헬스와 뷰티에 따라 디폴트 버튼 고정 / 안내 문구 원래는 없애기 / 마지막 글 쓸때 작성 글 보이게 수정!
- [마이페이지] 주문내역 없거나 값 못불러와도 주문 틀 존재하도록 수정
- [주문내역, 마이페이지] 가격에 콤마 추가
- [저장한 조합 목록 페이지] 값 없을 때 문구 추가
- 주문취소나 교환신청시 next버튼 main purple

## 📸스크린샷 (선택)

## 💬 공유사항 to 리뷰어
