### PR TITLE
[REFACTOR] 주문/결제 UI 개선

### DIFF
--- a/app/src/main/java/com/refit/app/data/me/model/OrdersResponse.kt
+++ b/app/src/main/java/com/refit/app/data/me/model/OrdersResponse.kt
@@ -6,17 +6,34 @@ data class OrderItemDto(
     val orderCode: String,
     val productName: String,
     val thumbnailUrl: String,
-    val createdAt: String,
-    val price: Int,
-    val originalPrice: Int,
-    val status: Int,
-    val quantity: Int,
-    val brand: String
+    val createdAt: String, // ISO string (ZonedDateTime → 문자열)
+
+    val unitPrice: Long,
+    val originalUnitPrice: Long,
+    val discountRate: Long,
+    val lineAmount: Long,
+
+    val status: Long,
+    val quantity: Long,
+    val canceledCount: Long,
+    val quantityRemaining: Long,
+    val brand: String,
+
+    // 주문 레벨(아이템에도 함께 실려옴)
+    val originalMerchandiseTotal: Long,
+    val currentMerchandiseSubtotal: Long,
+    val freeShippingApplied: Int,
+    val deliveryFee: Long
 )
 
 data class OrderResponse(
     val orderId: String,
-    val items: List<OrderItemDto>
+    val items: List<OrderItemDto>,
+
+    val originalMerchandiseTotal: Long,
+    val currentMerchandiseSubtotal: Long,
+    val freeShippingApplied: Int,
+    val deliveryFee: Long
 )
 
 data class OrdersResponse(

--- a/app/src/main/java/com/refit/app/data/payment/model/ConfirmPaymentResponse.kt
+++ b/app/src/main/java/com/refit/app/data/payment/model/ConfirmPaymentResponse.kt
@@ -9,5 +9,22 @@ data class ConfirmPaymentResponse(
     val totalAmount: Long,
     val status: String,
     val receiptUrl: String?,
-    val orderPk: Long? = null
+    val orderPk: Long? = null,
+    val orderCode: String,
+    val orderName: String,
+    val method: String,
+    val firstItemThumb: String,
+    val itemCount: Int,
+    val items: List<ConfirmPaymentItem>
+)
+
+@Serializable
+data class ConfirmPaymentItem(
+    val productId: Long,
+    val brandName: String,
+    val productName: String,
+    val price: Long,
+    val originalPrice: Long,
+    val quantity: Int,
+    val thumnailUrl: String
 )

--- a/app/src/main/java/com/refit/app/ui/composable/common/AppBarFor.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/common/AppBarFor.kt
@@ -47,13 +47,13 @@ fun appBarFor(route: String, nav: NavHostController): AppBarConfig {
             )
 
         route in listOf("notifications", "cart", "myfit/register") || route.startsWith("myfit/edit")
-                || route.startsWith("checkout/orderSheet") || route.startsWith("tossPay")
+                || route.startsWith("checkout/") || route.startsWith("tossPay")
                 || route.startsWith("chat") || route.startsWith("productList") ->
             AppBarConfig.BackOnly(
                 title = if (route == "notifications") "알림함"
                 else if (route == "cart") "장바구니"
                 else if (route == "myfit/register") "상품 등록"
-                else if (route.startsWith("checkout/orderSheet")) "주문/결제"
+                else if (route.startsWith("checkout/")) "주문/결제"
                 else if (route.startsWith("myfit/edit")) "상품 수정"
                 else if (route.startsWith("chatbot")) "챗봇 상담"
                 else if (route.startsWith("chat")) "그룹채팅"

--- a/app/src/main/java/com/refit/app/ui/composable/common/CompleteDialog.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/common/CompleteDialog.kt
@@ -1,0 +1,87 @@
+package com.refit.app.ui.composable.common
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.refit.app.R
+import com.refit.app.ui.theme.MainPurple
+
+@Composable
+fun CompleteDialog(
+    visible: Boolean,
+    title: String,
+    message: String,
+    confirmText: String = "확인",
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit = onConfirm
+) {
+    if (!visible) return
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        icon = {
+            Image(
+                painter = painterResource(id = R.drawable.ic_exclamation_fill),
+                contentDescription = null,
+                modifier = Modifier.size(60.dp)
+            )
+        },
+        title = {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        },
+        text = {
+            Text(
+                text = message,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        },
+        confirmButton = {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Button(
+                    onClick = onConfirm,
+                    shape = RoundedCornerShape(12.dp),
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MainPurple,
+                        contentColor = Color.White
+                    ),
+                    modifier = Modifier
+                        .height(44.dp)
+                        .weight(1f)
+                ) { Text(confirmText) }
+            }
+        },
+        dismissButton = null,
+        shape = RoundedCornerShape(16.dp),
+        containerColor = Color.White
+    )
+}

--- a/app/src/main/java/com/refit/app/ui/composable/common/MainScreenWithBottomNav.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/common/MainScreenWithBottomNav.kt
@@ -33,6 +33,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.launch
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.net.URLDecoder
+import kotlinx.serialization.decodeFromString
 import com.refit.app.data.order.flow.CheckoutFlowStore
 import com.refit.app.data.cart.api.CartApi
 import com.refit.app.data.cart.repository.CartRepository
@@ -79,6 +83,8 @@ import com.refit.app.data.product.model.Product
 import com.refit.app.ui.screen.CombinationRegisterScreen
 import com.refit.app.ui.screen.ProductSelectScreen
 import com.refit.app.data.order.model.decodeDraftOrderRequest
+import com.refit.app.ui.composable.order.CompleteItemNav
+import com.refit.app.ui.composable.order.OrderCompleteScreen
 import com.refit.app.ui.screen.ResultRouterScreen
 import com.refit.app.ui.screen.ChatbotScreen
 import com.refit.app.ui.screen.ProductListScreen
@@ -574,6 +580,7 @@ fun MainScreenWithBottomNav(
                         )
                     }
 
+                    // 결제 트랜잭션 처리용 게이트웨이 화면
                     composable(
                         route = "checkout/payResult?paymentKey={paymentKey}&orderId={orderId}&amount={amount}",
                         deepLinks = listOf(
@@ -594,34 +601,42 @@ fun MainScreenWithBottomNav(
                         val cartApi  = remember { RetrofitInstance.create(CartApi::class.java) }
                         val cartRepo = remember { CartRepository(cartApi) }
                         val scope    = rememberCoroutineScope()
+                        fun enc(s: String) = java.net.URLEncoder.encode(s, "utf-8")
 
                         com.refit.app.ui.composable.order.PayResultHandler(
                             navController = navController,
                             paymentKey = paymentKey,
                             orderId = orderId,
                             amount = amount,
-                            onSuccessNavigate = { orderPk ->
-                                // 선택했던 장바구니 항목들 삭제
+                            onSuccessNavigate = { payload ->
+
+                                // 장바구니 정리
                                 scope.launch {
                                     val ids = CheckoutFlowStore.selectedCartIds.value
                                     if (ids.isNotEmpty()) {
-                                        // 서버가 이미 정리하는 경우도 있으니 에러는 무시
                                         runCatching { cartRepo.deleteBulk(ids) }
                                         CheckoutFlowStore.clear()
-                                        // 뱃지/목록 갱신 콜백
                                         onCartChanged()
                                     }
                                 }
 
-                                // 성공 후 이동 로직. orderPk가 없으면 마이페이지로 보내는 등 정책 결정
-                                if (orderPk > 0) {
-                                    navController.navigate("orders") {
-                                        popUpTo(NavRoutes.CheckoutRoot) { inclusive = true }
-                                    }
-                                } else {
-                                    navController.navigate("my") {
-                                        popUpTo(NavRoutes.CheckoutRoot) { inclusive = true }
-                                    }
+                                // items를 JSON으로 직렬화해 쿼리로 전달
+                                val itemsParam = URLEncoder.encode(Json.encodeToString(payload.items), "utf-8")
+
+                                val dest = buildString {
+                                    append("checkout/complete")
+                                    append("?orderCode=${enc(payload.orderCode)}")
+                                    append("&amount=${payload.amount}")
+                                    append("&orderName=${enc(payload.orderName ?: "")}")
+                                    append("&method=${enc(payload.method ?: "")}")
+                                    append("&thumb=${enc(payload.thumb ?: "")}")
+                                    append("&itemCount=${payload.itemCount ?: -1}")
+                                    append("&items=$itemsParam")
+                                }
+
+                                navController.navigate(dest) {
+                                    popUpTo(NavRoutes.CheckoutRoot) { inclusive = true }
+                                    launchSingleTop = true
                                 }
                             },
                             onFailNavigate = {
@@ -642,6 +657,52 @@ fun MainScreenWithBottomNav(
                         val code = backStackEntry.arguments?.getString("code") ?: "UNKNOWN"
                         val message = backStackEntry.arguments?.getString("message") ?: ""
                         PayFailScreen(navController = navController, code = code, message = message)
+                    }
+
+                    // 결제 완료 페이지
+                    composable(
+                        route = "checkout/complete?orderCode={orderCode}&amount={amount}&orderName={orderName}&method={method}&thumb={thumb}&itemCount={itemCount}&items={items}",
+                        arguments = listOf(
+                            navArgument("orderCode") { type = NavType.StringType },
+                            navArgument("amount")    { type = NavType.LongType },
+                            navArgument("orderName") { type = NavType.StringType; nullable = true; defaultValue = null },
+                            navArgument("method")    { type = NavType.StringType; nullable = true; defaultValue = null },
+                            navArgument("thumb")     { type = NavType.StringType; nullable = true; defaultValue = null },
+                            navArgument("itemCount") { type = NavType.IntType;   defaultValue = -1 },
+                            navArgument("items")     { type = NavType.StringType; nullable = true; defaultValue = null }
+                        )
+                    ) { back ->
+                        val orderCode = back.arguments!!.getString("orderCode")!!
+                        val amount    = back.arguments!!.getLong("amount")
+                        val orderName = back.arguments?.getString("orderName")?.let { URLDecoder.decode(it, "utf-8") }
+                        val method    = back.arguments?.getString("method")
+                        val thumb     = back.arguments?.getString("thumb")
+                        val itemCountArg = back.arguments?.getInt("itemCount") ?: -1
+                        val itemCount = if (itemCountArg >= 0) itemCountArg else null
+
+                        val itemsArg = back.arguments?.getString("items")
+                        val items: List<CompleteItemNav> = try {
+                            if (!itemsArg.isNullOrBlank()) {
+                                val decoded = URLDecoder.decode(itemsArg, "utf-8")
+                                val list = Json.decodeFromString<List<CompleteItemNav>>(decoded)
+                                android.util.Log.d("ORDER_COMPLETE", "decoded items = ${list.size}")
+                                list
+                            } else emptyList()
+                        } catch (t: Throwable) {
+                            android.util.Log.e("ORDER_COMPLETE", "decode fail", t)
+                            emptyList()
+                        }
+
+                        OrderCompleteScreen(
+                            navController = navController,
+                            orderCode = orderCode,
+                            amount = amount,
+                            orderName = orderName,
+                            method = method,
+                            thumb = thumb,
+                            itemCount = itemCount,
+                            items = items
+                        )
                     }
 
                     composable(

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/CancelOrderReasonDialog.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/CancelOrderReasonDialog.kt
@@ -19,12 +19,16 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
+import java.text.NumberFormat
+import java.util.Locale
 
 @Composable
 fun CancelOrderReasonDialog(
     orderItemId: Long,
-    unitPrice: Int,
-    maxQty: Int,           // 최대 취소 가능 수량 (UI 상에선 item.quantity 사용)
+    unitPrice: Long,
+    maxQty: Int,      // quantityRemaining
+    originalMerchandiseTotal: Long,   // 주문 당시 상품 총액(배송비 제외)
+    currentMerchandiseSubtotal: Long, // 이번 취소 직전 남아있는 상품 총액
     onDismiss: () -> Unit,
     onConfirmCancel: (orderItemId: Long, reason: String, count: Int) -> Unit
 ) {
@@ -33,6 +37,16 @@ fun CancelOrderReasonDialog(
     var selectedCount by remember { mutableStateOf(1) }
 
     val reasons = listOf("상품이 마음에 들지 않음", "더 저렴한 상품을 발견함", "잘못된 상품을 주문함")
+
+    val freeShippingThreshold = 30_000L
+    val shippingFee = 3_000L
+
+    val baseRefund: Long = unitPrice * selectedCount
+    val remainAfterThisCancel: Long = currentMerchandiseSubtotal - baseRefund
+    val originallyFree = originalMerchandiseTotal >= freeShippingThreshold
+    val shouldChargeShipping = originallyFree && (remainAfterThisCancel < freeShippingThreshold)
+    val shippingDeduct = if (shouldChargeShipping) shippingFee else 0L
+    val expectedRefund = (baseRefund - shippingDeduct).coerceAtLeast(0L)
 
     Dialog(onDismissRequest = onDismiss) {
         Surface(
@@ -117,13 +131,16 @@ fun CancelOrderReasonDialog(
                         }
 
                         // 미리보기(환불 금액)
-                        Text(
-                            text = "환불 예정 금액: ${unitPrice * selectedCount}원",
-                            fontFamily = Pretendard,
-                            fontWeight = FontWeight.SemiBold,
-                            fontSize = 14.sp,
-                            color = MainPurple
-                        )
+                        Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                            Text("기본 환불액: ${baseRefund.comma()}원")
+                            if (shouldChargeShipping) {
+                                Text("배송비 차감: -${shippingDeduct.comma()}원 \n(취소 후 30,000원 미만)")
+                            }
+                            Text(
+                                "환불 예정 금액: ${expectedRefund.comma()}원",
+                                color = MainPurple, fontWeight = FontWeight.SemiBold
+                            )
+                        }
                     }
 
                     if (step == 2) {
@@ -161,3 +178,6 @@ fun CancelOrderReasonDialog(
         }
     }
 }
+
+fun Long.comma(): String = NumberFormat.getNumberInstance(Locale.KOREA).format(this)
+fun Int.comma(): String  = NumberFormat.getNumberInstance(Locale.KOREA).format(this)

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/CancelOrderReasonDialog.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/CancelOrderReasonDialog.kt
@@ -132,8 +132,8 @@ fun CancelOrderReasonDialog(
 
                         // 미리보기(환불 금액)
                         Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                            Text("기본 환불액: ${baseRefund.comma()}원")
                             if (shouldChargeShipping) {
+                                Text("기본 환불액: ${baseRefund.comma()}원")
                                 Text("배송비 차감: -${shippingDeduct.comma()}원 \n(취소 후 30,000원 미만)")
                             }
                             Text(

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/OrderItemRow.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/OrderItemRow.kt
@@ -1,21 +1,11 @@
 package com.refit.app.ui.composable.mypage
 
-import android.view.LayoutInflater
-import android.widget.TextView
-import android.widget.Toast
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import com.refit.app.R
-import androidx.compose.material3.Icon
-import androidx.compose.material3.SnackbarDuration
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.SnackbarResult
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,16 +14,14 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.AsyncImage
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.navigation.NavController
+import com.refit.app.R
 import com.refit.app.data.me.model.OrderItemDto
 import com.refit.app.data.me.modelAndView.OrderViewModel
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
-import androidx.navigation.NavController
 import com.refit.app.data.cart.modelAndView.CartEditViewModel
 import com.refit.app.util.common.PriceUtil
 import com.refit.app.util.order.OrderStatusMapper
@@ -43,6 +31,9 @@ import kotlinx.coroutines.launch
 @Composable
 fun OrderItemRow(
     item: OrderItemDto,
+    orderOriginalMerchTotal: Long,
+    orderCurrentMerchSubtotal: Long,
+
     vm: OrderViewModel,
     cartVm: CartEditViewModel,
     onCartChanged: () -> Unit,
@@ -50,15 +41,12 @@ fun OrderItemRow(
     snackbarHostState: SnackbarHostState,
     scope: CoroutineScope
 ) {
-    val context = LocalContext.current
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 8.dp)
     ) {
-        // 상태 텍스트
-        val statusText = OrderStatusMapper.getStatusText(item.status)
+        val statusText = OrderStatusMapper.getStatusText(item.status.toInt())
 
         Text(
             text = statusText,
@@ -72,9 +60,7 @@ fun OrderItemRow(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable {
-                    navController.navigate("product/${item.productId}")
-                },
+                .clickable { navController.navigate("product/${item.productId}") },
             verticalAlignment = Alignment.CenterVertically
         ) {
             // 상품 이미지
@@ -97,16 +83,16 @@ fun OrderItemRow(
                 // 가격/수량
                 Row {
                     Text(
-                        text = PriceUtil.formatPrice(item.price.toLong()),
+                        text = PriceUtil.formatPrice(item.unitPrice),
                         fontFamily = Pretendard,
                         fontSize = 15.sp,
                         fontWeight = FontWeight.Bold,
                         modifier = Modifier.alignByBaseline()
                     )
-                    if (item.originalPrice > item.price) {
+                    if (item.originalUnitPrice > item.unitPrice) {
                         Spacer(Modifier.width(4.dp))
                         Text(
-                            text = PriceUtil.formatPrice(item.originalPrice.toLong()),
+                            text = PriceUtil.formatPrice(item.originalUnitPrice),
                             fontFamily = Pretendard,
                             fontSize = 12.sp,
                             color = Color.Gray,
@@ -125,17 +111,19 @@ fun OrderItemRow(
                 }
 
                 // 주문취소 버튼 (결제완료일 때만)
-                if (item.status == 1) {
+                if (item.status == 1L) {
                     var showCancelDialog by remember { mutableStateOf(false) }
 
                     if (showCancelDialog) {
                         CancelOrderReasonDialog(
                             orderItemId = item.orderItemId,
-                            unitPrice = item.price,
-                            maxQty = item.quantity,
+                            unitPrice = item.unitPrice,
+                            maxQty = item.quantityRemaining.toInt().coerceAtLeast(0), //  남은 수량
+                            originalMerchandiseTotal = orderOriginalMerchTotal,       // 주문 당시 총액
+                            currentMerchandiseSubtotal = orderCurrentMerchSubtotal,   // 현재 남은 총액
                             onDismiss = { showCancelDialog = false },
                             onConfirmCancel = { id, reason, count ->
-                                vm.requestCancel(id, item.price, count, reason)
+                                vm.requestCancel(id, item.unitPrice.toInt(), count, reason)
                             }
                         )
                     }
@@ -149,10 +137,9 @@ fun OrderItemRow(
                 }
 
                 // 교환/반품 버튼 (배송완료일 때만)
-                if (item.status == 6) {
+                if (item.status == 6L) {
                     var showDialog by remember { mutableStateOf(false) }
 
-                    // 교환/반품 다이얼로그
                     if (showDialog) {
                         ExchangeReturnReasonDialog(
                             orderItemId = item.orderItemId,
@@ -182,9 +169,9 @@ fun OrderItemRow(
                         )
                     }
                 }
-
             }
 
+            // 장바구니 담기 버튼
             Box(
                 modifier = Modifier
                     .align(Alignment.CenterVertically)
@@ -195,7 +182,6 @@ fun OrderItemRow(
                         cartVm.addOne(item.productId, 1)
                         scope.launch {
                             snackbarHostState.currentSnackbarData?.dismiss()
-
                             val result = snackbarHostState.showSnackbar(
                                 message = "${item.productName}을 장바구니에 담았어요.",
                                 actionLabel = "바로가기",

--- a/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/mypage/RecentOrderSection.kt
@@ -8,9 +8,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,10 +22,7 @@ import com.refit.app.data.me.model.OrderResponse
 import com.refit.app.ui.theme.LightPurple
 import com.refit.app.ui.theme.MainPurple
 import com.refit.app.ui.theme.Pretendard
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.navigation.NavController
 import com.refit.app.R
@@ -37,7 +32,6 @@ import com.refit.app.util.common.PriceUtil
 import com.refit.app.util.order.OrderStatusMapper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-
 
 @Composable
 fun RecentOrderSection(
@@ -50,8 +44,6 @@ fun RecentOrderSection(
     snackbarHostState: SnackbarHostState,
     scope: CoroutineScope
 ) {
-    val context = LocalContext.current
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -102,7 +94,6 @@ fun RecentOrderSection(
 
         Spacer(Modifier.height(8.dp))
 
-        // 주문 내역 카드 → 흰색
         Card(
             shape = RoundedCornerShape(12.dp),
             colors = CardDefaults.cardColors(containerColor = Color.White),
@@ -160,9 +151,7 @@ fun RecentOrderSection(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(vertical = 8.dp)
-                                .clickable {
-                                    navController.navigate("product/${item.productId}")
-                                },
+                                .clickable { navController.navigate("product/${item.productId}") },
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
                         ) {
@@ -175,7 +164,7 @@ fun RecentOrderSection(
                                 Spacer(Modifier.width(12.dp))
                                 Column {
                                     Text(
-                                        text = OrderStatusMapper.getStatusText(item.status),
+                                        text = OrderStatusMapper.getStatusText(item.status.toInt()),
                                         color = MainPurple,
                                         fontSize = 12.sp,
                                         fontFamily = Pretendard,
@@ -190,16 +179,16 @@ fun RecentOrderSection(
                                     )
                                     Row {
                                         Text(
-                                            text = PriceUtil.formatPrice(item.price.toLong()),
+                                            text = PriceUtil.formatPrice(item.unitPrice),
                                             fontSize = 13.sp,
                                             fontWeight = FontWeight.Bold,
                                             fontFamily = Pretendard,
                                             modifier = Modifier.alignByBaseline()
                                         )
-                                        if (item.originalPrice > item.price) {
+                                        if (item.originalUnitPrice > item.unitPrice) {
                                             Spacer(Modifier.width(6.dp))
                                             Text(
-                                                text = PriceUtil.formatPrice(item.originalPrice.toLong()),
+                                                text = PriceUtil.formatPrice(item.originalUnitPrice),
                                                 fontSize = 12.sp,
                                                 fontFamily = Pretendard,
                                                 color = Color.Gray,
@@ -218,35 +207,21 @@ fun RecentOrderSection(
                                     }
 
                                     // 결제완료 → 주문취소 버튼
-                                    if (item.status == 1) {
+                                    if (item.status.toInt() == 1) {
                                         var showCancelDialog by remember { mutableStateOf(false) }
 
                                         if (showCancelDialog) {
-                                            // 남은 취소 가능 수량 계산
-                                            // item.canceledCount 가 없다면 아래 remainQty는 item.quantity 로 둠
-                                            val remainQty = run {
-                                                val canceled = try {
-                                                    @Suppress("UNUSED_VARIABLE")
-                                                    (item::class.java.getDeclaredField("canceledCount")
-                                                        .apply { isAccessible = true }
-                                                        .get(item) as? Int) ?: 0
-                                                } catch (_: Exception) {
-                                                    0
-                                                }
-                                                val q = item.quantity - canceled
-                                                if (q < 1) 1 else q
-                                            }
-
                                             CancelOrderReasonDialog(
                                                 orderItemId = item.orderItemId,
-                                                unitPrice = item.price,
-                                                maxQty = remainQty,
+                                                unitPrice = item.unitPrice,
+                                                maxQty = item.quantityRemaining.toInt().coerceAtLeast(0),
+                                                originalMerchandiseTotal = order.originalMerchandiseTotal,   // 주문 당시 총액
+                                                currentMerchandiseSubtotal = order.currentMerchandiseSubtotal, // 현재 남은 총액
                                                 onDismiss = { showCancelDialog = false },
                                                 onConfirmCancel = { id, reason, count ->
-                                                    //  cancelAmount = unitPrice * count 으로 요청
                                                     vm.requestCancel(
                                                         orderItemId = id,
-                                                        unitPrice = item.price,
+                                                        unitPrice = item.unitPrice.toInt(),
                                                         count = count,
                                                         reason = reason
                                                     )
@@ -265,7 +240,7 @@ fun RecentOrderSection(
                                     }
 
                                     // 배송완료 → 교환/반품 신청 버튼
-                                    if (item.status == 6) {
+                                    if (item.status.toInt() == 6) {
                                         var showDialog by remember { mutableStateOf(false) }
 
                                         if (showDialog) {
@@ -289,6 +264,7 @@ fun RecentOrderSection(
                                 }
                             }
 
+                            // 장바구니 담기
                             Box(
                                 modifier = Modifier
                                     .align(Alignment.CenterVertically)
@@ -299,7 +275,6 @@ fun RecentOrderSection(
                                         cartVm.addOne(item.productId, 1)
                                         scope.launch {
                                             snackbarHostState.currentSnackbarData?.dismiss()
-
                                             val result = snackbarHostState.showSnackbar(
                                                 message = "${item.productName}을 장바구니에 담았어요.",
                                                 actionLabel = "바로가기",
@@ -329,10 +304,5 @@ fun RecentOrderSection(
     }
 }
 
-private fun String.limitWithEllipsis(maxLength: Int): String {
-    return if (this.length > maxLength) {
-        this.take(maxLength) + "..."
-    } else {
-        this
-    }
-}
+private fun String.limitWithEllipsis(maxLength: Int): String =
+    if (this.length > maxLength) this.take(maxLength) + "..." else this

--- a/app/src/main/java/com/refit/app/ui/composable/order/OrderCompleteScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/order/OrderCompleteScreen.kt
@@ -1,0 +1,155 @@
+package com.refit.app.ui.composable.order
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import coil.compose.AsyncImage
+import com.refit.app.ui.theme.MainPurple
+import com.refit.app.ui.theme.Pretendard
+import java.text.DecimalFormat
+
+@Composable
+fun OrderCompleteScreen(
+    navController: NavController,
+    orderCode: String,
+    amount: Long,
+    orderName: String?,
+    method: String?,
+    thumb: String?,
+    itemCount: Int?,
+    items: List<CompleteItemNav> = emptyList()
+) {
+    val titleStyle = TextStyle(fontFamily = Pretendard, fontWeight = FontWeight.Bold, fontSize = 20.sp)
+    val bodyStyle  = TextStyle(fontFamily = Pretendard, fontSize = 14.sp)
+    val money = DecimalFormat("#,###").format(amount)
+    val scroll = rememberScrollState()
+
+    Scaffold(containerColor = Color.White) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+                .verticalScroll(scroll)
+                .padding(horizontal = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Spacer(Modifier.height(36.dp))
+
+            // 상단 축하/완료 영역
+            Text("주문이 완료되었습니다", style = titleStyle)
+            Spacer(Modifier.height(8.dp))
+            Text("주문 내역은 마이 > 주문내역에서 확인할 수 있어요.", style = bodyStyle.copy(color = Color(0xFF6F737A)))
+
+            Spacer(Modifier.height(24.dp))
+
+            // 요약 카드 (결제 정보 + 주문 상품을 '같은 카드'에 배치)
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color(0xFFF8F8FA))
+                    .padding(16.dp)
+            ) {
+                // 상품명/주문번호
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(Modifier.weight(1f)) {
+                        val nameLine = when {
+                            !orderName.isNullOrBlank() -> orderName
+                            (itemCount ?: -1) > 0      -> "상품 ${itemCount}개"
+                            else                       -> "상품"
+                        }
+                        Text(nameLine ?: "상품", style = bodyStyle.copy(fontWeight = FontWeight.SemiBold))
+                        Spacer(Modifier.height(4.dp))
+                        Text("주문번호 $orderCode", style = bodyStyle.copy(color = Color(0xFF8C8C8C), fontSize = 12.sp))
+                    }
+                }
+
+                Spacer(Modifier.height(12.dp))
+                HorizontalDivider(color = Color(0xFFE8E8EE))
+                Spacer(Modifier.height(12.dp))
+
+                // 결제 정보
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                    Text("결제금액", style = bodyStyle.copy(color = Color(0xFF6F737A)))
+                    Text("${money}원", style = bodyStyle.copy(fontWeight = FontWeight.Bold, fontSize = 16.sp))
+                }
+                if (!method.isNullOrBlank()) {
+                    Spacer(Modifier.height(6.dp))
+                    Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                        Text("결제수단", style = bodyStyle.copy(color = Color(0xFF6F737A)))
+                        Text(methodLabel(method), style = bodyStyle)
+                    }
+                }
+
+                // 주문 상품 (카드 내부, 결제 정보 아래)
+                if (items.isNotEmpty()) {
+                    Spacer(Modifier.height(16.dp))
+                    HorizontalDivider(color = Color(0xFFE8E8EE))
+                    Spacer(Modifier.height(12.dp))
+
+                    Text("주문 상품", style = bodyStyle.copy(fontWeight = FontWeight.SemiBold))
+                    Spacer(Modifier.height(8.dp))
+
+                    items.forEach { it ->
+                        OrderItemMiniRow(
+                            item = CompleteItemUi(
+                                productId     = it.productId,
+                                brand         = it.brand,           // 서버 필드명은 brandName, 네비 DTO가 brand로 받음
+                                productName   = it.productName,
+                                price         = it.price,
+                                originalPrice = it.originalPrice,
+                                quantity      = it.quantity,
+                                thumbnailUrl  = it.thumbnailUrl
+                            ),
+                            onClickProduct = { pid ->
+                                navController.navigate("product/$pid")
+                            }
+                        )
+                        Spacer(Modifier.height(8.dp))
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(28.dp))
+
+            // 홈으로 가기
+            Button(
+                onClick = {
+                    navController.navigate("home") {
+                        popUpTo("home") { inclusive = true }
+                        launchSingleTop = true
+                    }
+                },
+                colors = ButtonDefaults.buttonColors(containerColor = MainPurple, contentColor = Color.White),
+                shape = RoundedCornerShape(12.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(50.dp),
+                elevation = ButtonDefaults.buttonElevation(defaultElevation = 0.dp)
+            ) {
+                Text("홈으로 가기")
+            }
+        }
+    }
+}
+
+private fun methodLabel(code: String): String = when (code) {
+    "CARD" -> "신용카드"
+    "VIRTUAL_ACCOUNT" -> "가상계좌"
+    "TRANSFER" -> "계좌이체"
+    "MOBILE_PHONE" -> "휴대폰결제"
+    else -> code
+}

--- a/app/src/main/java/com/refit/app/ui/composable/order/OrderItemMiniRow.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/order/OrderItemMiniRow.kt
@@ -1,0 +1,80 @@
+package com.refit.app.ui.composable.order
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.refit.app.ui.theme.Pretendard
+import java.text.DecimalFormat
+
+data class CompleteItemUi(
+    val productId: Long,
+    val brand: String,
+    val productName: String,
+    val price: Long,
+    val originalPrice: Long,
+    val quantity: Int,
+    val thumbnailUrl: String
+)
+
+@Composable
+fun OrderItemMiniRow(
+    item: CompleteItemUi,
+    onClickProduct: ((Long) -> Unit)? = null
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+    ) {
+        AsyncImage(
+            model = item.thumbnailUrl,
+            contentDescription = item.productName,
+            modifier = Modifier.size(64.dp)
+        )
+        Spacer(Modifier.width(12.dp))
+
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = "[${item.brand}] ${item.productName}",
+                fontFamily = Pretendard,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Medium
+            )
+            Spacer(Modifier.height(4.dp))
+
+            Row {
+                val money = DecimalFormat("#,###")
+                Text(
+                    text = "${money.format(item.price)}원",
+                    fontFamily = Pretendard,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold
+                )
+                if (item.originalPrice > item.price) {
+                    Spacer(Modifier.width(6.dp))
+                    Text(
+                        text = "${money.format(item.originalPrice)}원",
+                        fontFamily = Pretendard,
+                        fontSize = 12.sp,
+                        color = Color.Gray,
+                        textDecoration = TextDecoration.LineThrough
+                    )
+                }
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    text = "| ${item.quantity}개",
+                    fontFamily = Pretendard,
+                    fontSize = 13.sp,
+                    color = Color.Gray
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/refit/app/ui/composable/order/PayResultHandler.kt
+++ b/app/src/main/java/com/refit/app/ui/composable/order/PayResultHandler.kt
@@ -15,10 +15,33 @@ import kotlinx.serialization.json.*
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.refit.app.R
 import com.refit.app.ui.theme.MainPurple
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CompleteItemNav(
+    val productId: Long,
+    val brand: String,
+    val productName: String,
+    val price: Long,
+    val originalPrice: Long,
+    val quantity: Int,
+    val thumbnailUrl: String
+)
+
+@Serializable
+data class OrderCompletePayload(
+    val orderPk: Long,
+    val orderCode: String,
+    val orderName: String?,
+    val amount: Long,
+    val method: String?,
+    val thumb: String?,
+    val itemCount: Int?,
+    val items: List<CompleteItemNav>
+)
 
 @Composable
 fun PayResultHandler(
@@ -26,11 +49,7 @@ fun PayResultHandler(
     paymentKey: String,
     orderId: String,
     amount: Long,
-    onSuccessNavigate: (orderPk: Long) -> Unit = { orderPk ->
-        navController.navigate("orders") {
-            popUpTo("splash") { inclusive = false }
-        }
-    },
+    onSuccessNavigate: (OrderCompletePayload) -> Unit,
     onFailNavigate: () -> Unit = {} // 자동 이동 금지
 ) {
     val scope = rememberCoroutineScope()
@@ -63,9 +82,44 @@ fun PayResultHandler(
                     return@launch
                 }
 
-                val orderPk = json["orderPk"]?.jsonPrimitive?.longOrNull ?: 0L
+                val orderPk   = json["orderPk"]?.jsonPrimitive?.longOrNull ?: 0L
+                val orderCode = json["orderCode"]?.jsonPrimitive?.contentOrNull ?: orderId
+                val orderName = json["orderName"]?.jsonPrimitive?.contentOrNull
+                val method    = json["method"]?.jsonPrimitive?.contentOrNull
+                val totalAmt  = json["totalAmount"]?.jsonPrimitive?.longOrNull ?: amount
+                val thumb     = json["firstItemThumb"]?.jsonPrimitive?.contentOrNull
+                val itemCount = json["itemCount"]?.jsonPrimitive?.intOrNull
+
+                //  items 파싱
+                val items: List<CompleteItemNav> =
+                    (json["items"] as? JsonArray)?.mapNotNull { el ->
+                        val obj = el.jsonObject
+                        val pid = obj["productId"]?.jsonPrimitive?.longOrNull ?: return@mapNotNull null
+                        CompleteItemNav(
+                            productId     = pid,
+                            brand         = obj["brandName"]?.jsonPrimitive?.contentOrNull ?: "",
+                            productName   = obj["productName"]?.jsonPrimitive?.contentOrNull ?: "",
+                            price         = obj["price"]?.jsonPrimitive?.longOrNull ?: 0L,
+                            originalPrice = obj["originalPrice"]?.jsonPrimitive?.longOrNull ?: 0L,
+                            quantity      = obj["quantity"]?.jsonPrimitive?.intOrNull ?: 1,
+                            thumbnailUrl  = obj["thumbnailUrl"]?.jsonPrimitive?.contentOrNull ?: ""
+                        )
+                    } ?: emptyList()
+
                 loading = false
-                onSuccessNavigate(orderPk)
+
+                onSuccessNavigate(
+                    OrderCompletePayload(
+                        orderPk    = orderPk,
+                        orderCode  = orderCode,
+                        orderName  = orderName,
+                        amount     = totalAmt,
+                        method     = method,
+                        thumb      = thumb,
+                        itemCount  = itemCount,
+                        items      = items
+                    )
+                )
             }.onFailure { t ->
                 netErr = t.message ?: "결제 확인 실패"
                 loading = false

--- a/app/src/main/java/com/refit/app/ui/screen/OrderListScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/OrderListScreen.kt
@@ -163,7 +163,9 @@ fun OrderListScreen(
                                             onCartChanged = onCartChanged,
                                             navController = navController,
                                             snackbarHostState = snackbarHostState,
-                                            scope = scope
+                                            scope = scope,
+                                            orderOriginalMerchTotal = order.originalMerchandiseTotal,
+                                            orderCurrentMerchSubtotal = order.currentMerchandiseSubtotal
                                         )
                                         Spacer(Modifier.height(12.dp))
                                     }

--- a/app/src/main/java/com/refit/app/ui/screen/order/OrderSheetScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/order/OrderSheetScreen.kt
@@ -33,6 +33,7 @@ import com.refit.app.ui.theme.Pretendard
 import java.text.DecimalFormat
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.ui.unit.Dp
 
 @Composable
 fun OrderSheetScreen(
@@ -150,7 +151,6 @@ fun OrderSheetScreen(
 
                     // 5) 약관 동의
                     item { SectionTerms(ui.consentTerms, onToggle = vm::toggleTerms) }
-                    item { Spacer(Modifier.height(8.dp)) }
                 }
             }
         }
@@ -172,6 +172,15 @@ private val BodyTextStyle = TextStyle(
 private val moneyFormatter = DecimalFormat("#,###")
 private fun won(n: Long) = moneyFormatter.format(n)
 
+private fun formatKoreanPhone(raw: String): String {
+    val digits = raw.filter { it.isDigit() }
+    return when (digits.length) {
+        11 -> "${digits.substring(0,3)}-${digits.substring(3,7)}-${digits.substring(7,11)}"
+        10 -> "${digits.substring(0,3)}-${digits.substring(3,6)}-${digits.substring(6,10)}"
+        else -> raw
+    }
+}
+
 /* ================= 공통 섹션 요소 ================= */
 
 @Composable
@@ -183,15 +192,18 @@ private fun SectionTitle(text: String) {
     )
 }
 
-/** 각 영역을 이미지처럼 두꺼운 회색 블럭으로 구분 */
+// 각 영역을 이미지처럼 두꺼운 회색 블럭으로 구분
 @Composable
-private fun SectionSeparator() {
+private fun SectionSeparator(
+    topSpacing: Dp = 16.dp,
+    blockHeight: Dp = 8.dp
+) {
     Spacer(
         Modifier
             .fillMaxWidth()
-            .height(8.dp)
+            .padding(top = topSpacing)
+            .height(blockHeight)
             .background(Color(0xFFF5F5F7))
-            .padding(vertical = 20.dp)
     )
 }
 
@@ -199,7 +211,6 @@ private fun SectionSeparator() {
 
 @Composable
 private fun SectionShipping(info: ShippingInfo) {
-    // 얇은 연회색 테두리 + 둥근 모서리 + 내부 흰색 카드
     Column(
         Modifier
             .padding(horizontal = 16.dp, vertical = 8.dp)
@@ -212,7 +223,8 @@ private fun SectionShipping(info: ShippingInfo) {
             .background(Color.White)
             .padding(16.dp)
     ) {
-        Text("${info.receiverName} · ${info.phone}", style = BodyTextStyle)
+        val phone = formatKoreanPhone(info.phone)
+        Text("${info.receiverName} · $phone", style = BodyTextStyle)
         Spacer(Modifier.height(6.dp))
         Text("${info.roadAddress} ${info.detailAddress} [${info.zipcode}]", style = BodyTextStyle)
         info.memo?.let {
@@ -326,11 +338,11 @@ private fun SectionAmountBlock(summary: AmountSummary) {
 
     Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)) {
         // 상품금액(정가 총액)
-        AmountRow("상품금액(정가)", "${won(productTotal)} 원")
+        AmountRow("상품금액 (정가)", "${won(productTotal)} 원")
         // 할인금액
         AmountRow("할인금액", "-${won(summary.discount)} 원")
         // 주문금액(할인가 총액)
-        AmountRow("주문금액(할인가)", "${won(summary.goodsAmount)} 원")
+        AmountRow("주문금액 (할인가)", "${won(summary.goodsAmount)} 원")
 
         // 배송비는 그대로 표기
         AmountRow("배송비", "${won(summary.deliveryFee)} 원")
@@ -370,7 +382,12 @@ private fun AmountRow(label: String, value: String) {
 
 @Composable
 private fun SectionTerms(checked: Boolean, onToggle: (Boolean) -> Unit) {
-    Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp)) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(top = 12.dp)
+    ) {
         Row(
             Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/app/src/main/java/com/refit/app/ui/screen/order/OrderSheetScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/order/OrderSheetScreen.kt
@@ -310,14 +310,23 @@ private fun SectionPayMethod(selected: String, onSelect: (String) -> Unit) {
             val isSelected = (value == selected)
             val borderColor = if (isSelected) MainPurple else Color(0xFFE0E0E6)
             val bg = if (isSelected) MainPurple.copy(alpha = 0.08f) else Color.White
+            val textColor = if (isSelected) MainPurple else Color.Black
+
             OutlinedButton(
                 onClick = { onSelect(value) },
                 shape = RoundedCornerShape(5.dp),
                 border = BorderStroke(1.dp, borderColor),
-                colors = ButtonDefaults.outlinedButtonColors(containerColor = bg),
+                colors = ButtonDefaults.outlinedButtonColors(
+                    containerColor = bg,
+                    contentColor = textColor
+                ),
                 contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp)
             ) {
-                Text(label, style = BodyTextStyle.copy(fontWeight = FontWeight.Medium))
+                Text(
+                    text = label,
+                    style = BodyTextStyle.copy(fontWeight = FontWeight.Medium),
+                    color = textColor
+                )
             }
         }
     }

--- a/app/src/main/java/com/refit/app/ui/screen/order/TossWebViewScreen.kt
+++ b/app/src/main/java/com/refit/app/ui/screen/order/TossWebViewScreen.kt
@@ -10,7 +10,10 @@ import android.webkit.WebChromeClient
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.navigation.NavController
 import java.net.URLEncoder
@@ -36,7 +39,13 @@ fun TossWebViewScreen(
           <title>Toss Pay</title>
           <style>
             html,body{margin:0;padding:0;height:100%;font-family:system-ui,-apple-system,Segoe UI,Roboto}
-            .wrap{display:flex;align-items:center;justify-content:center;height:100%}
+            .wrap{
+                position: fixed;      
+                inset: 0;             
+                display: flex;
+                align-items: center; 
+                justify-content: center; 
+            }
             .msg{opacity:.7}
           </style>
         </head>
@@ -129,6 +138,8 @@ fun TossWebViewScreen(
     """.trimIndent()
 
     AndroidView(
+        modifier = Modifier
+            .fillMaxSize(),
         factory = { ctx ->
             WebView(ctx).apply {
 


### PR DESCRIPTION
## #️⃣ Issue Number
- close #87

## 📝 요약(Summary)
- 주문 완료 페이지 추가
- 주문서 페이지 : 동의체크 아래 여백 제거
- 주문서 페이지 : 전화번호 표기 방식 수정
- 주문서 페이지 : 각 섹션 내부 여백 수정
- '결제창을 불러오는 중입니다' 문구 위치 변경
- 결제 취소 모달창에서 예상 환불액에 배송비 고려하도록 수정하고 콤마 추가

## 📸스크린샷 (선택)

| <img  height="700" alt="결제완료_최종" src="https://github.com/user-attachments/assets/802a3dfe-3e9d-47f7-83bb-74a1aa1f4b12" /> | <img  height="700" alt="결제창불러오는중" src="https://github.com/user-attachments/assets/a1b9a7dc-44e2-4b39-8925-88638aa3c7f4" />|
|------|------|

<br/>

|<img  height="700" alt="주문서_new1" src="https://github.com/user-attachments/assets/4a43faba-b2ba-458b-9d14-b543030df797" /> |<img height="700" alt="주문서_new2" src="https://github.com/user-attachments/assets/07680661-a8ed-4f75-ae16-31d4e60b75ba" />| 
|------|------|

<br/>

| <img  height="700" alt="취소1" src="https://github.com/user-attachments/assets/ad9a762e-52b5-4f6a-98c6-6ebb7a3a4d80" />| <img  height="700" alt="취소3" src="https://github.com/user-attachments/assets/3794dc76-b8ee-4b89-ba63-29437044e080" />|
|------|------|



